### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/access/pg_tde_ddl.c
+++ b/src/access/pg_tde_ddl.c
@@ -32,10 +32,11 @@ static void
  tdeheap_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
                              int subId, void *arg)
  {
+    Relation    rel = NULL;
+
     if (prev_object_access_hook)
         prev_object_access_hook(access, classId, objectId, subId, arg);
 
-     Relation    rel = NULL;
      if (access == OAT_DROP && classId == RelationRelationId)
      {
         ObjectAccessDrop *drop_arg = (ObjectAccessDrop *) arg;

--- a/src/catalog/tde_keyring.c
+++ b/src/catalog/tde_keyring.c
@@ -598,9 +598,9 @@ load_vaultV2_keyring_provider_options(char *keyring_options)
 		ereport(WARNING,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("missing in the keyring options:%s%s%s",
-							!vaultV2_keyring->vault_token ? " token" : "",
-							!vaultV2_keyring->vault_url ? " url" : "",
-							!vaultV2_keyring->vault_mount_path ? " mountPath" : "")));
+							*(vaultV2_keyring->vault_token) ? "" : " token",
+							*(vaultV2_keyring->vault_url) ? "" : " url",
+							*(vaultV2_keyring->vault_mount_path) ? "" : " mountPath")));
 		return NULL;
 	}
 
@@ -664,7 +664,7 @@ fetch_next_key_provider(int fd, off_t* curr_pos, KeyringProvideRecord *provider)
 		ereport(ERROR,
 				(errcode_for_file_access(),
 					errmsg("key provider info file is corrupted: %m"),
-					errdetail("invalid key provider record size %ld expected %lu", bytes_read, sizeof(KeyringProvideRecord) )));
+					errdetail("invalid key provider record size %lld expected %lu", bytes_read, sizeof(KeyringProvideRecord) )));
 	}
 	return true;
 }

--- a/src/catalog/tde_principal_key.c
+++ b/src/catalog/tde_principal_key.c
@@ -76,6 +76,7 @@ static void shared_memory_shutdown(int code, Datum arg);
 static void principal_key_startup_cleanup(int tde_tbl_count, XLogExtensionInstall *ext_info, bool redo, void *arg);
 static void clear_principal_key_cache(Oid databaseId) ;
 static inline dshash_table *get_principal_key_Hash(void);
+static TDEPrincipalKey *get_principal_key_from_keyring(Oid dbOid, Oid spcOid);
 static TDEPrincipalKey *get_principal_key_from_cache(Oid dbOid);
 static void push_principal_key_to_cache(TDEPrincipalKey *principalKey);
 static Datum pg_tde_get_key_info(PG_FUNCTION_ARGS, Oid dbOid, Oid spcOid);

--- a/src/keyring/keyring_file.c
+++ b/src/keyring/keyring_file.c
@@ -81,7 +81,7 @@ get_key_by_name(GenericKeyring* keyring, const char* key_name, bool throw_error,
 				(errcode_for_file_access(),
 					errmsg("keyring file \"%s\" is corrupted: %m",
 						file_keyring->file_name),
-						errdetail("invalid key size %lu expected %lu", bytes_read, sizeof(keyInfo))));
+						errdetail("invalid key size %llu expected %lu", bytes_read, sizeof(keyInfo))));
 			return NULL;
 		}
 		if (strncasecmp(key->name.name, key_name, sizeof(key->name.name)) == 0)


### PR DESCRIPTION
1.  address of array 'vaultV2_keyring->vault_mount_path' will always evaluate to 'true' [-Wpointer-bool-conversion]
2. format specifies type 'long' but the argument has type 'off_t' (aka 'long long') [-Wformat]
3. no previous prototype for function 'get_principal_key_from_keyring' [-Wmissing-prototypes]
4. mixing declarations and code is incompatible with standards before C99 [-Wdeclaration-after-statement]