### PR TITLE
Handle recreated relations in smgr encryption

### DIFF
--- a/.github/workflows/postgresql-17-src-meson.yml
+++ b/.github/workflows/postgresql-17-src-meson.yml
@@ -70,5 +70,6 @@ jobs:
         with:
           name: Regressions diff and postgresql log
           path: |
-            src/build/testrun/pg_tde/regress/
+            src/build/testrun/pg_tde/
+            src/contrib/pg_tde/t/results/
           retention-days: 3

--- a/src16/access/pg_tdeam_handler.c
+++ b/src16/access/pg_tdeam_handler.c
@@ -599,6 +599,9 @@ pg_tdeam_relation_set_new_filelocator(Relation rel,
 									MultiXactId *minmulti)
 {
 	SMgrRelation srel;
+#ifdef PERCONA_EXT
+	RelFileLocator oldlocator = rel->rd_locator;
+#endif
 
 	/*
 	 * Initialize to the minimum XID that could put tuples in the table. We
@@ -617,7 +620,11 @@ pg_tdeam_relation_set_new_filelocator(Relation rel,
 	 */
 	*minmulti = GetOldestMultiXactId();
 
+#ifdef PERCONA_EXT
+	srel = RelationCreateStorage(oldlocator, *newrlocator, persistence, true);
+#else
 	srel = RelationCreateStorage(*newrlocator, persistence, true);
+#endif
 
 	/*
 	 * If required, set up an init fork for an unlogged table so that it can
@@ -633,7 +640,11 @@ pg_tdeam_relation_set_new_filelocator(Relation rel,
 		Assert(rel->rd_rel->relkind == RELKIND_RELATION ||
 			   rel->rd_rel->relkind == RELKIND_MATVIEW ||
 			   rel->rd_rel->relkind == RELKIND_TOASTVALUE);
+#ifdef PERCONA_EXT
+		smgrcreate(oldlocator, srel, INIT_FORKNUM, false);
+#else
 		smgrcreate(srel, INIT_FORKNUM, false);
+#endif
 		log_smgrcreate(newrlocator, INIT_FORKNUM);
 		smgrimmedsync(srel, INIT_FORKNUM);
 	}
@@ -680,7 +691,11 @@ pg_tdeam_relation_copy_data(Relation rel, const RelFileLocator *newrlocator)
 	 * NOTE: any conflict in relfilenumber value will be caught in
 	 * RelationCreateStorage().
 	 */
+#ifdef PERCONA_EXT
+	RelationCreateStorage(rel->rd_locator, *newrlocator, rel->rd_rel->relpersistence, true);
+#else
 	RelationCreateStorage(*newrlocator, rel->rd_rel->relpersistence, true);
+#endif
 
 	/* copy main fork */
 	RelationCopyStorage(RelationGetSmgr(rel), dstrel, MAIN_FORKNUM,
@@ -692,7 +707,11 @@ pg_tdeam_relation_copy_data(Relation rel, const RelFileLocator *newrlocator)
 	{
 		if (smgrexists(RelationGetSmgr(rel), forkNum))
 		{
+#ifdef PERCONA_EXT
+			smgrcreate(rel->rd_locator, dstrel, forkNum, false);
+#else
 			smgrcreate(dstrel, forkNum, false);
+#endif
 
 			/*
 			 * WAL log creation if the relation is persistent, or this is the

--- a/t/008_tde_heap.pl
+++ b/t/008_tde_heap.pl
@@ -52,14 +52,21 @@ ok($rt_value == 1, "Restart Server");
 $rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
 $rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');", extra_params => ['-a']);
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
+
+
+######################### test_enc1 (simple create table w tde_heap)
+
+
+$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc1(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc1 (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
+
+######################### test_enc2 (create heap + alter to tde_heap)
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc2(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -73,8 +80,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', 'SET default_table_access_method = "tde_heap";', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+######################### test_enc3 (default_table_access_method)
 
 $stdout = $node->safe_psql('postgres', 'SET default_table_access_method = "tde_heap"; CREATE TABLE test_enc3(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -85,13 +91,36 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc3 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
+######################### test_enc4 (create heap + alter default)
+
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc4(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc4 (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-
 $stdout = $node->safe_psql('postgres', 'SET default_table_access_method = "tde_heap"; ALTER TABLE test_enc4 SET ACCESS METHOD DEFAULT;', extra_params => ['-a']);
+
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc4 ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+
+######################### test_enc5 (create tde_heap + truncate)
+
+$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc5(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc5 (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'CHECKPOINT;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'TRUNCATE test_enc5;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc5 (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc5 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 # Restart the server
@@ -99,31 +128,40 @@ PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+sub verify_table
+{
+    PGTDE::append_to_file('###########################');
 
-# Verify that we can't see the data in the file
-my $tablefile = $node->safe_psql('postgres', 'SHOW data_directory;');
-$tablefile .= '/';
-$tablefile .= $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\'test_enc\');');
+    my ($table) = @_;
 
-my $strings = 'TABLEFILE FOUND: ';
-$strings .= `(ls  $tablefile >/dev/null && echo yes) || echo no`;
-PGTDE::append_to_file($strings);
+    my $tablefile = $node->safe_psql('postgres', 'SHOW data_directory;');
+    $tablefile .= '/';
+    $tablefile .= $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\''.$table.'\');');
 
-$strings = 'CONTAINS FOO (should be empty): ';
-$strings .= `strings $tablefile | grep foo`;
-PGTDE::append_to_file($strings);
+    $stdout = $node->safe_psql('postgres', 'SELECT * FROM ' . $table . ' ORDER BY id ASC;', extra_params => ['-a']);
+    PGTDE::append_to_file($stdout);
 
+    my $strings = 'TABLEFILE FOR ' . $table . ' FOUND: ';
+    $strings .= `(ls  $tablefile >/dev/null && echo -n yes) || echo -n no`;
+    PGTDE::append_to_file($strings);
 
+    $strings = 'CONTAINS FOO (should be empty): ';
+    $strings .= `strings $tablefile | grep foo`;
+    PGTDE::append_to_file($strings);
+}
 
+verify_table('test_enc1');
+verify_table('test_enc2');
+verify_table('test_enc3');
+verify_table('test_enc4');
+verify_table('test_enc5');
 
 # Verify that we can't see the data in the file
 my $tablefile2 = $node->safe_psql('postgres', 'SHOW data_directory;');
 $tablefile2 .= '/';
 $tablefile2 .= $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\'test_enc2\');');
 
-$strings = 'TABLEFILE2 FOUND: ';
+my  $strings = 'TABLEFILE2 FOUND: ';
 $strings .= `(ls  $tablefile2 >/dev/null && echo yes) || echo no`;
 PGTDE::append_to_file($strings);
 
@@ -165,7 +203,7 @@ PGTDE::append_to_file($strings);
 
 
 
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc;', extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc1;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc2;', extra_params => ['-a']);
@@ -175,6 +213,9 @@ $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc3;', extra_params => 
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc4;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc5;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 # DROP EXTENSION

--- a/t/expected/008_tde_heap.out
+++ b/t/expected/008_tde_heap.out
@@ -1,8 +1,8 @@
 CREATE EXTENSION pg_tde;
 -- server restart
-CREATE TABLE test_enc(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
-INSERT INTO test_enc (k) VALUES ('foobar'),('barfoo');
-SELECT * FROM test_enc ORDER BY id ASC;
+CREATE TABLE test_enc1(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc1 (k) VALUES ('foobar'),('barfoo');
+SELECT * FROM test_enc1 ORDER BY id ASC;
 1|foobar
 2|barfoo
 CREATE TABLE test_enc2(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));
@@ -11,21 +11,53 @@ ALTER TABLE test_enc2 SET ACCESS METHOD tde_heap;
 SELECT * FROM test_enc2 ORDER BY id ASC;
 1|foobar
 2|barfoo
-SET default_table_access_method = "tde_heap";
 SET default_table_access_method = "tde_heap"; CREATE TABLE test_enc3(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));
 INSERT INTO test_enc3 (k) VALUES ('foobar'),('barfoo');
 SELECT * FROM test_enc3 ORDER BY id ASC;
 1|foobar
 2|barfoo
-CREATE TABLE test_enc4(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING heap;
 INSERT INTO test_enc4 (k) VALUES ('foobar'),('barfoo');
-SET default_table_access_method = "tde_heap"; ALTER TABLE test_enc4 SET ACCESS METHOD DEFAULT;
--- server restart
-SELECT * FROM test_enc ORDER BY id ASC;
+SELECT * FROM test_enc4 ORDER BY id ASC;
 1|foobar
 2|barfoo
-TABLEFILE FOUND: yes
-
+CREATE TABLE test_enc5(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc5 (k) VALUES ('foobar'),('barfoo');
+CHECKPOINT;
+TRUNCATE test_enc5;
+INSERT INTO test_enc5 (k) VALUES ('foobar'),('barfoo');
+SELECT * FROM test_enc5 ORDER BY id ASC;
+3|foobar
+4|barfoo
+-- server restart
+###########################
+SELECT * FROM test_enc1 ORDER BY id ASC;
+1|foobar
+2|barfoo
+TABLEFILE FOR test_enc1 FOUND: yes
+CONTAINS FOO (should be empty): 
+###########################
+SELECT * FROM test_enc2 ORDER BY id ASC;
+1|foobar
+2|barfoo
+TABLEFILE FOR test_enc2 FOUND: yes
+CONTAINS FOO (should be empty): 
+###########################
+SELECT * FROM test_enc3 ORDER BY id ASC;
+1|foobar
+2|barfoo
+TABLEFILE FOR test_enc3 FOUND: yes
+CONTAINS FOO (should be empty): 
+###########################
+SELECT * FROM test_enc4 ORDER BY id ASC;
+1|foobar
+2|barfoo
+TABLEFILE FOR test_enc4 FOUND: yes
+CONTAINS FOO (should be empty): 
+###########################
+SELECT * FROM test_enc5 ORDER BY id ASC;
+3|foobar
+4|barfoo
+TABLEFILE FOR test_enc5 FOUND: yes
 CONTAINS FOO (should be empty): 
 TABLEFILE2 FOUND: yes
 
@@ -36,8 +68,9 @@ CONTAINS FOO (should be empty):
 TABLEFILE4 FOUND: yes
 
 CONTAINS FOO (should be empty): 
-DROP TABLE test_enc;
+DROP TABLE test_enc1;
 DROP TABLE test_enc2;
 DROP TABLE test_enc3;
 DROP TABLE test_enc4;
+DROP TABLE test_enc5;
 DROP EXTENSION pg_tde;


### PR DESCRIPTION
Previously operations that created a new relation file for some reason (truncate for example) resulted in a new unencrypted file, even if the original file was encrypted.

This commit changes this behavior to properly create a new internal key for the new internal file in this case.

This only works in pair with the related core change in the postgres repository.