### PR TITLE
Fix tde trigger for alter index

### DIFF
--- a/src/pg_tde_event_capture.c
+++ b/src/pg_tde_event_capture.c
@@ -135,13 +135,9 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 	{
 		LOCKMODE	lockmode = AccessShareLock; /* TODO. Verify lock mode? */
 		AlterTableStmt *stmt = (AlterTableStmt *) parsetree;
-		TDEPrincipalKey * principal_key;
-		Oid		relationId = RangeVarGetRelid(stmt->relation, NoLock, true);
-		Relation	rel = table_open(relationId, lockmode);
-		Oid tablespace_oid = rel->rd_locator.spcOid;
 		ListCell   *lcmd;
-		table_close(rel, lockmode);
 
+		/* TODO: it might make sense to cehck rd_rel->relkind  */
 		foreach(lcmd, stmt->cmds)
         	{
 			AlterTableCmd *cmd = (AlterTableCmd *) lfirst(lcmd);
@@ -156,6 +152,12 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 
 		if (tdeCurrentCreateEvent.encryptMode)
 		{
+			TDEPrincipalKey * principal_key;
+			Oid		relationId = RangeVarGetRelid(stmt->relation, NoLock, true);
+			Relation	rel = table_open(relationId, lockmode);
+			Oid tablespace_oid = rel->rd_locator.spcOid;
+			table_close(rel, lockmode);
+
 			LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
 			principal_key = GetPrincipalKey(MyDatabaseId, tablespace_oid, LW_SHARED);
 			LWLockRelease(tde_lwlock_enc_keys());


### PR DESCRIPTION
AlterTableStmt path of the trigger event tried to open any relation as a table but ALTER INDEX triggers this path as well which leads to an error. It makes sense to open the table only after we make sure it is a table and in interest of ours.

For PG-1107, PG-1108, PG-1109, PG-1110