### PR TITLE
Fix trigger for ALTER TABLE SET ACCESS METHOD DEFAULT

### DIFF
--- a/src/pg_tde_event_capture.c
+++ b/src/pg_tde_event_capture.c
@@ -137,11 +137,14 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 		AlterTableStmt *stmt = (AlterTableStmt *) parsetree;
 		ListCell   *lcmd;
 
-		/* TODO: it might make sense to cehck rd_rel->relkind  */
 		foreach(lcmd, stmt->cmds)
-        	{
+		{
 			AlterTableCmd *cmd = (AlterTableCmd *) lfirst(lcmd);
-			if(cmd->subtype == AT_SetAccessMethod && strcmp(cmd->name, "tde_heap")==0) {
+			if (cmd->subtype == AT_SetAccessMethod && 
+				(cmd->name != NULL && strcmp(cmd->name, "tde_heap")==0) ||
+				(cmd->name == NULL && strcmp(default_table_access_method, "tde_heap") == 0)
+				)
+			{
 				tdeCurrentCreateEvent.encryptMode = true;
 				tdeCurrentCreateEvent.eventType = TDE_TABLE_CREATE_EVENT;
 				tdeCurrentCreateEvent.relation = stmt->relation;

--- a/t/expected/008_tde_heap.out
+++ b/t/expected/008_tde_heap.out
@@ -17,6 +17,9 @@ INSERT INTO test_enc3 (k) VALUES ('foobar'),('barfoo');
 SELECT * FROM test_enc3 ORDER BY id ASC;
 1|foobar
 2|barfoo
+CREATE TABLE test_enc4(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING heap;
+INSERT INTO test_enc4 (k) VALUES ('foobar'),('barfoo');
+SET default_table_access_method = "tde_heap"; ALTER TABLE test_enc4 SET ACCESS METHOD DEFAULT;
 -- server restart
 SELECT * FROM test_enc ORDER BY id ASC;
 1|foobar
@@ -30,7 +33,11 @@ CONTAINS FOO (should be empty):
 TABLEFILE3 FOUND: yes
 
 CONTAINS FOO (should be empty): 
+TABLEFILE4 FOUND: yes
+
+CONTAINS FOO (should be empty): 
 DROP TABLE test_enc;
 DROP TABLE test_enc2;
 DROP TABLE test_enc3;
+DROP TABLE test_enc4;
 DROP EXTENSION pg_tde;


### PR DESCRIPTION
1. cmd-> The name is empty (NULL) in the case of `ACCESS METHOD DEFAULT`, so we should check for NULL before cmp.

2. Make trigger aware of the case when default AM is `tde_heap`

Fixes PG-1106