### PR TITLE
Fix CREATE/DROP tde_heap in non-default tablespace

### DIFF
--- a/expected/tablespace.out
+++ b/expected/tablespace.out
@@ -38,4 +38,9 @@ SELECT * FROM test WHERE num1=110;
 
 DROP TABLE test;
 DROP TABLESPACE test_tblspace;
+-- check CREATE in non-default tablespace
+CREATE TABLESPACE test_tblspace2 LOCATION '';
+CREATE TABLE test(num1 bigint, num2 double precision, t text) USING :tde_am TABLESPACE test_tblspace2;
+DROP TABLE test;
+DROP TABLESPACE test_tblspace2;
 DROP EXTENSION pg_tde;

--- a/expected/tablespace_basic.out
+++ b/expected/tablespace_basic.out
@@ -38,4 +38,9 @@ SELECT * FROM test WHERE num1=110;
 
 DROP TABLE test;
 DROP TABLESPACE test_tblspace;
+-- check CREATE in non-default tablespace
+CREATE TABLESPACE test_tblspace2 LOCATION '';
+CREATE TABLE test(num1 bigint, num2 double precision, t text) USING :tde_am TABLESPACE test_tblspace2;
+DROP TABLE test;
+DROP TABLESPACE test_tblspace2;
 DROP EXTENSION pg_tde;

--- a/sql/tablespace.inc
+++ b/sql/tablespace.inc
@@ -23,4 +23,11 @@ SELECT * FROM test WHERE num1=110;
 
 DROP TABLE test;
 DROP TABLESPACE test_tblspace;
+
+-- check CREATE in non-default tablespace
+CREATE TABLESPACE test_tblspace2 LOCATION '';
+CREATE TABLE test(num1 bigint, num2 double precision, t text) USING :tde_am TABLESPACE test_tblspace2;
+
+DROP TABLE test;
+DROP TABLESPACE test_tblspace2;
 DROP EXTENSION pg_tde;

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -72,7 +72,8 @@ extern RelKeyData *tde_create_rel_key(RelFileNumber rel_num, InternalKey *key, T
 extern RelKeyData *tde_encrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyData *rel_key_data, const RelFileLocator *rlocator);
 extern RelKeyData *tde_decrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyData *enc_rel_key_data, const RelFileLocator *rlocator);
 extern RelKeyData *pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool no_map_ok);
-extern bool pg_tde_move_rel_key(const RelFileLocator *newrlocator, const RelFileLocator *oldrlocator);
+extern void pg_tde_move_rel_key(const RelFileLocator *newrlocator, const RelFileLocator *oldrlocator);
+extern void pg_tde_clean_map_data(const RelFileLocator *rlocator);
 
 extern void pg_tde_set_db_file_paths(Oid dbOid, Oid spcOid, char *map_path, char *keydata_path);
 

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -73,7 +73,7 @@ extern RelKeyData *tde_encrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyDat
 extern RelKeyData *tde_decrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyData *enc_rel_key_data, const RelFileLocator *rlocator);
 extern RelKeyData *pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool no_map_ok);
 extern void pg_tde_move_rel_key(const RelFileLocator *newrlocator, const RelFileLocator *oldrlocator);
-extern void pg_tde_clean_map_data(const RelFileLocator *rlocator);
+extern void pg_tde_clean_map_data(const RelFileLocator *rlocator, bool error_on_failure);
 
 extern void pg_tde_set_db_file_paths(Oid dbOid, Oid spcOid, char *map_path, char *keydata_path);
 

--- a/src/pg_tde_event_capture.c
+++ b/src/pg_tde_event_capture.c
@@ -141,7 +141,7 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 		foreach(lcmd, stmt->cmds)
 		{
 			AlterTableCmd *cmd = (AlterTableCmd *) lfirst(lcmd);
-			if (cmd->subtype == AT_SetAccessMethod && 
+			if ((cmd->subtype == AT_SetAccessMethod || cmd->subtype == AT_SetTableSpace) && 
 				((cmd->name != NULL && strcmp(cmd->name, "tde_heap")==0) ||
 				 (cmd->name == NULL && strcmp(default_table_access_method, "tde_heap") == 0))
 				)

--- a/src/smgr/pg_tde_smgr.c
+++ b/src/smgr/pg_tde_smgr.c
@@ -289,7 +289,11 @@ tde_mdopen(SMgrRelation reln)
 static void
 tde_mdunlink(RelFileLocatorBackend rlocator, ForkNumber forknum, bool isRedo)
 {
-	pg_tde_clean_map_data(&rlocator.locator);
+	/* 
+	 * tde_mdunlink() being called after the transaction is commited, so we
+	 * cannot have any errors down the call stack.
+	 */
+	pg_tde_clean_map_data(&rlocator.locator, false);
 
 	mdunlink(rlocator, forknum, isRedo);
 }


### PR DESCRIPTION
1. `tde_mdopen()` is called before `tde_mdcreate()` during CREATE. In the case of non-default tablespace, the creation of the key will fail in tde_mdopen(), as the storage is yet to be created (namely database dir). This doesn't happen with default table space because the db dir had been already created before the CREATE TABLE call.
2. When dropping/moving relations in non-default table space we also have clean-up `*.tde` files. And remove those files physically if there is nothing (tde related) left in the table space. Otherwise `DROP TABLESPACE` will fail.
One caveat is that `tde_mdunlink()` is called after the transaction is commited, so we must not have any errors down the call stack. For that, we need related tdemap* functions to have an option of not failing on error.

Fixes PG-1196