### PR TITLE
Add documentation dependencies to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/documentation"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds documentation folder to dependabot configuration (Python PIP package manager)