### PR TITLE
Move pg_tde files to one dir inside PGDATA

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -128,7 +128,7 @@ if get_variable('percona_ext', false)
       'trigger_on_view',
       'change_access_method',
       'insert_update_delete',
-      # 'tablespace',
+      'tablespace',
       'vault_v2_test',
       'alter_index',
       'merge_join',

--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -160,7 +160,7 @@ pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type
 	LWLock *lock_pk = tde_lwlock_enc_keys();
 
 	LWLockAcquire(lock_pk, LW_EXCLUSIVE);
-	principal_key = GetPrincipalKey(newrlocator->dbOid, newrlocator->spcOid, LW_EXCLUSIVE);
+	principal_key = GetPrincipalKey(newrlocator->dbOid, LW_EXCLUSIVE);
 	if (principal_key == NULL)
 	{
 		LWLockRelease(lock_pk);
@@ -875,7 +875,7 @@ pg_tde_move_rel_key(const RelFileLocator *newrlocator, const RelFileLocator *old
 
 	LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
 
-	principal_key = GetPrincipalKey(oldrlocator->dbOid, oldrlocator->spcOid, LW_EXCLUSIVE);
+	principal_key = GetPrincipalKey(oldrlocator->dbOid, LW_EXCLUSIVE);
 	Assert(principal_key);
 
 	key_index = pg_tde_process_map_entry(oldrlocator, MAP_ENTRY_VALID, db_map_path, &offset, false);
@@ -946,7 +946,7 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool n
 	 * key.
 	 */
 	LWLockAcquire(lock_pk, LW_SHARED);
-	principal_key = GetPrincipalKey(rlocator->dbOid, rlocator->spcOid, LW_SHARED);
+	principal_key = GetPrincipalKey(rlocator->dbOid, LW_SHARED);
 	if (principal_key == NULL)
 	{
 		LWLockRelease(lock_pk);

--- a/src/access/pg_tde_xlog.c
+++ b/src/access/pg_tde_xlog.c
@@ -114,7 +114,7 @@ tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 	{
 		XLogExtensionInstall *xlrec = (XLogExtensionInstall *) XLogRecGetData(record);
 
-		appendStringInfo(buf, "tde extension install for db %u/%u", xlrec->database_id, xlrec->tablespace_id);
+		appendStringInfo(buf, "tde extension install for db %u", xlrec->database_id);
 	}
 	if (info == XLOG_TDE_ROTATE_KEY)
 	{

--- a/src/access/pg_tde_xlog.c
+++ b/src/access/pg_tde_xlog.c
@@ -17,7 +17,6 @@
 #include "access/xlog.h"
 #include "access/xlog_internal.h"
 #include "access/xloginsert.h"
-#include "catalog/pg_tablespace_d.h"
 #include "catalog/tde_keyring.h"
 #include "storage/bufmgr.h"
 #include "storage/shmem.h"
@@ -108,7 +107,7 @@ tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 	{
 		TDEPrincipalKeyInfo *xlrec = (TDEPrincipalKeyInfo *) XLogRecGetData(record);
 
-		appendStringInfo(buf, "add tde principal key for db %u/%u", xlrec->databaseId, xlrec->tablespaceId);
+		appendStringInfo(buf, "add tde principal key for db %u", xlrec->databaseId);
 	}
 	if (info == XLOG_TDE_EXTENSION_INSTALL_KEY)
 	{

--- a/src/access/pg_tde_xlog_encrypt.c
+++ b/src/access/pg_tde_xlog_encrypt.c
@@ -18,7 +18,6 @@
 #include "access/xlog.h"
 #include "access/xlog_internal.h"
 #include "access/xloginsert.h"
-#include "catalog/pg_tablespace_d.h"
 #include "storage/bufmgr.h"
 #include "storage/shmem.h"
 #include "utils/guc.h"

--- a/src/catalog/tde_global_space.c
+++ b/src/catalog/tde_global_space.c
@@ -115,7 +115,7 @@ init_default_keyring(void)
 		 * TODO: should we remove it automaticaly on
 		 * pg_tde_rotate_principal_key() ?
 		 */
-		save_new_key_provider_info(&provider, GLOBAL_DATA_TDE_OID, GLOBALTABLESPACE_OID, false);
+		save_new_key_provider_info(&provider, GLOBAL_DATA_TDE_OID, false);
 		elog(INFO,
 			 "default keyring has been created for the global tablespace (WAL)."
 			 " Change it with pg_tde_add_key_provider_* and run pg_tde_rotate_principal_key."

--- a/src/catalog/tde_global_space.c
+++ b/src/catalog/tde_global_space.c
@@ -36,7 +36,7 @@
 #define KEYRING_DEFAULT_FILE_NAME "pg_tde_default_keyring_CHANGE_AND_REMOVE_IT"
 
 #define DefaultKeyProvider GetKeyProviderByName(KEYRING_DEFAULT_NAME, \
-										GLOBAL_DATA_TDE_OID, GLOBALTABLESPACE_OID)
+												GLOBAL_DATA_TDE_OID)
 
 #ifndef FRONTEND
 static void init_keys(void);
@@ -53,7 +53,7 @@ TDEInitGlobalKeys(const char *dir)
 #ifndef FRONTEND
 	char db_map_path[MAXPGPATH] = {0};
 
-	pg_tde_set_db_file_paths(GLOBAL_DATA_TDE_OID, GLOBALTABLESPACE_OID, db_map_path, NULL);
+	pg_tde_set_db_file_paths(GLOBAL_DATA_TDE_OID, db_map_path, NULL);
 	if (access(db_map_path, F_OK) == -1)
 	{
 		init_default_keyring();
@@ -87,7 +87,7 @@ TDEInitGlobalKeys(const char *dir)
 static void
 init_default_keyring(void)
 {
-	if (GetAllKeyringProviders(GLOBAL_DATA_TDE_OID, GLOBALTABLESPACE_OID) == NIL)
+	if (GetAllKeyringProviders(GLOBAL_DATA_TDE_OID) == NIL)
 	{
 		char path[MAXPGPATH] = {0};
 		static KeyringProvideRecord provider =
@@ -100,7 +100,7 @@ init_default_keyring(void)
 			elog(WARNING, "unable to get current working dir");
 
 		/* TODO: not sure about the location. Currently it's in $PGDATA */
-		join_path_components(path, path, KEYRING_DEFAULT_FILE_NAME);
+		join_path_components(path, PG_TDE_DATA_DIR, KEYRING_DEFAULT_FILE_NAME);
 
 		snprintf(provider.options, MAX_KEYRING_OPTION_LEN,
 				 "{"
@@ -108,6 +108,8 @@ init_default_keyring(void)
 				 "\"path\": \"%s\""
 				 "}", path
 			);
+
+		pg_tde_init_data_dir();
 
 		/*
 		 * TODO: should we remove it automaticaly on

--- a/src/catalog/tde_keyring.c
+++ b/src/catalog/tde_keyring.c
@@ -306,7 +306,7 @@ write_key_provider_info(KeyringProvideRecord *provider, Oid database_id,
  * Save the key provider info to the file
  */
 uint32
-save_new_key_provider_info(KeyringProvideRecord* provider, Oid databaseId, Oid tablespaceId, bool write_xlog)
+save_new_key_provider_info(KeyringProvideRecord* provider, Oid databaseId, bool write_xlog)
 {
 	return write_key_provider_info(provider, databaseId, -1, true, write_xlog);
 }
@@ -335,19 +335,12 @@ pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS)
 	char *options = text_to_cstring(PG_GETARG_TEXT_PP(2));
 	bool is_global = PG_GETARG_BOOL(3);
 	KeyringProvideRecord provider;
-	Oid dbOid = MyDatabaseId;
-	Oid spcOid = MyDatabaseTableSpace;
-
-	if (is_global)
-	{
-		dbOid = GLOBAL_DATA_TDE_OID;
-		spcOid = GLOBALTABLESPACE_OID;
-	}
+	Oid dbOid = is_global ? GLOBAL_DATA_TDE_OID : MyDatabaseId;
 
 	strncpy(provider.options, options, sizeof(provider.options));
 	strncpy(provider.provider_name, provider_name, sizeof(provider.provider_name));
 	provider.provider_type = get_keyring_provider_from_typename(provider_type);
-	save_new_key_provider_info(&provider, dbOid, spcOid, true);
+	save_new_key_provider_info(&provider, dbOid, true);
 
 	PG_RETURN_INT32(provider.provider_id);
 }

--- a/src/common/pg_tde_utils.c
+++ b/src/common/pg_tde_utils.c
@@ -93,22 +93,3 @@ pg_tde_set_globalspace_dir(const char *dir)
 	Assert(dir != NULL);
 	strncpy(globalspace_dir, dir, sizeof(globalspace_dir));
 }
-
-/* returns the palloc'd string */
-char *
-pg_tde_get_tde_file_dir(Oid dbOid, Oid spcOid)
-{
-	/*
-	 * `dbOid` is set to a value for the XLog keys caching but
-	 * GetDatabasePath() expects it (`dbOid`) to be `0` if this is a global
-	 * space.
-	 */
-	if (spcOid == GLOBALTABLESPACE_OID)
-	{
-		if (strlen(globalspace_dir) > 0)
-			return pstrdup(globalspace_dir);
-
-		return pstrdup("global");
-	}
-	return GetDatabasePath(dbOid, spcOid);
-}

--- a/src/common/pg_tde_utils.c
+++ b/src/common/pg_tde_utils.c
@@ -11,7 +11,6 @@
 
 #include "postgres.h"
 
-#include "catalog/pg_tablespace_d.h"
 #include "utils/snapmgr.h"
 #include "commands/defrem.h"
 #include "common/pg_tde_utils.h"

--- a/src/encryption/enc_tde.c
+++ b/src/encryption/enc_tde.c
@@ -240,15 +240,14 @@ PGTdePageAddItemExtended(RelFileLocator rel,
  * short lifespan until it is written to disk.
  */
 void
-AesEncryptKey(const TDEPrincipalKey *principal_key, const RelFileLocator *rlocator, RelKeyData *rel_key_data, RelKeyData **p_enc_rel_key_data, size_t *enc_key_bytes)
+AesEncryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, RelKeyData *rel_key_data, RelKeyData **p_enc_rel_key_data, size_t *enc_key_bytes)
 {
 	unsigned char iv[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 	/* Ensure we are getting a valid pointer here */
 	Assert(principal_key);
 
-	memcpy(iv, &rlocator->spcOid, sizeof(Oid));
-	memcpy(iv + sizeof(Oid), &rlocator->dbOid, sizeof(Oid));
+	memcpy(iv, &dbOid, sizeof(Oid));
 
 	*p_enc_rel_key_data = (RelKeyData *) palloc(sizeof(RelKeyData));
 	memcpy(*p_enc_rel_key_data, rel_key_data, sizeof(RelKeyData));
@@ -266,15 +265,14 @@ AesEncryptKey(const TDEPrincipalKey *principal_key, const RelFileLocator *rlocat
  * to our key cache.
  */
 void
-AesDecryptKey(const TDEPrincipalKey *principal_key, const RelFileLocator *rlocator, RelKeyData **p_rel_key_data, RelKeyData *enc_rel_key_data, size_t *key_bytes)
+AesDecryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, RelKeyData **p_rel_key_data, RelKeyData *enc_rel_key_data, size_t *key_bytes)
 {
 	unsigned char iv[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 	/* Ensure we are getting a valid pointer here */
 	Assert(principal_key);
 
-	memcpy(iv, &rlocator->spcOid, sizeof(Oid));
-	memcpy(iv + sizeof(Oid), &rlocator->dbOid, sizeof(Oid));
+	memcpy(iv, &dbOid, sizeof(Oid));
 
 #ifndef FRONTEND
 	MemoryContext oldcontext;

--- a/src/encryption/enc_tde.c
+++ b/src/encryption/enc_tde.c
@@ -205,7 +205,6 @@ pg_tde_crypt_tuple(HeapTuple tuple, HeapTuple out_tuple, RelKeyData *key, const 
 
 OffsetNumber
 PGTdePageAddItemExtended(RelFileLocator rel,
-						 Oid oid,
 						 BlockNumber bn,
 						 Page page,
 						 Item item,

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -8,6 +8,7 @@
 #ifndef PG_TDE_MAP_H
 #define PG_TDE_MAP_H
 
+#include "pg_tde.h"
 #include "utils/rel.h"
 #include "access/xlog_internal.h"
 #include "catalog/pg_tablespace_d.h"
@@ -62,9 +63,9 @@ extern RelKeyData *GetSMGRRelationKey(RelFileLocator rel);
 extern RelKeyData *GetHeapBaiscRelationKey(RelFileLocator rel);
 extern RelKeyData *GetTdeGlobaleRelationKey(RelFileLocator rel);
 
-extern void pg_tde_delete_tde_files(Oid dbOid, Oid spcOid);
+extern void pg_tde_delete_tde_files(Oid dbOid);
 
-extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid, Oid spcOid);
+extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
 extern bool pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info);
 extern bool pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern bool pg_tde_write_map_keydata_files(off_t map_size, char *m_file_data, off_t keydata_size, char *k_file_data);
@@ -74,7 +75,17 @@ extern RelKeyData *tde_decrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyDat
 extern RelKeyData *pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool no_map_ok);
 extern bool pg_tde_move_rel_key(const RelFileLocator *newrlocator, const RelFileLocator *oldrlocator);
 
-extern void pg_tde_set_db_file_paths(Oid dbOid, Oid spcOid, char *map_path, char *keydata_path);
+#define PG_TDE_MAP_FILENAME			"pg_tde_%d_map"
+#define PG_TDE_KEYDATA_FILENAME		"pg_tde_%d_dat"
+
+static inline void
+pg_tde_set_db_file_paths(Oid dbOid, char *map_path, char *keydata_path)
+{
+	if (map_path)
+		join_path_components(map_path, PG_TDE_DATA_DIR, psprintf(PG_TDE_MAP_FILENAME, dbOid));
+	if (keydata_path)
+		join_path_components(keydata_path, PG_TDE_DATA_DIR, psprintf(PG_TDE_KEYDATA_FILENAME, dbOid));
+}
 
 const char *tde_sprint_key(InternalKey *k);
 

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -11,7 +11,6 @@
 #include "pg_tde.h"
 #include "utils/rel.h"
 #include "access/xlog_internal.h"
-#include "catalog/pg_tablespace_d.h"
 #include "catalog/tde_principal_key.h"
 #include "storage/relfilelocator.h"
 
@@ -70,8 +69,8 @@ extern bool pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info);
 extern bool pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern bool pg_tde_write_map_keydata_files(off_t map_size, char *m_file_data, off_t keydata_size, char *k_file_data);
 extern RelKeyData *tde_create_rel_key(RelFileNumber rel_num, InternalKey *key, TDEPrincipalKeyInfo *principal_key_info);
-extern RelKeyData *tde_encrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyData *rel_key_data, const RelFileLocator *rlocator);
-extern RelKeyData *tde_decrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyData *enc_rel_key_data, const RelFileLocator *rlocator);
+extern RelKeyData *tde_encrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyData *rel_key_data, Oid dbOid);
+extern RelKeyData *tde_decrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyData *enc_rel_key_data, Oid dbOid);
 extern RelKeyData *pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool no_map_ok);
 extern bool pg_tde_move_rel_key(const RelFileLocator *newrlocator, const RelFileLocator *oldrlocator);
 

--- a/src/include/catalog/tde_global_space.h
+++ b/src/include/catalog/tde_global_space.h
@@ -12,6 +12,7 @@
 #define TDE_GLOBAL_CATALOG_H
 
 #include "postgres.h"
+#include "catalog/pg_tablespace_d.h"
 
 #include "access/pg_tde_tdemap.h"
 #include "catalog/tde_principal_key.h"

--- a/src/include/catalog/tde_global_space.h
+++ b/src/include/catalog/tde_global_space.h
@@ -21,7 +21,7 @@
  * We take Oids of the sql operators, so there is no overlap with the "real"
  * catalog objects possible.
  */
-#define GLOBAL_DATA_TDE_OID	InvalidOid
+#define GLOBAL_DATA_TDE_OID	607
 #define XLOG_TDE_OID        608
 
 #define GLOBAL_SPACE_RLOCATOR(_obj_oid) (RelFileLocator) { \
@@ -29,6 +29,8 @@
 	GLOBAL_DATA_TDE_OID, \
 	_obj_oid \
 }
+
+#define TDEisInGlobalSpace(dbOid) 	(dbOid == GLOBAL_DATA_TDE_OID)
 
 extern void TDEInitGlobalKeys(const char *dir);
 

--- a/src/include/catalog/tde_global_space.h
+++ b/src/include/catalog/tde_global_space.h
@@ -24,8 +24,6 @@
 #define GLOBAL_DATA_TDE_OID	InvalidOid
 #define XLOG_TDE_OID        608
 
-#define GLOBAL_DATA_TDE_OID	InvalidOid
-
 #define GLOBAL_SPACE_RLOCATOR(_obj_oid) (RelFileLocator) { \
 	GLOBALTABLESPACE_OID, \
 	GLOBAL_DATA_TDE_OID, \

--- a/src/include/catalog/tde_keyring.h
+++ b/src/include/catalog/tde_keyring.h
@@ -68,23 +68,19 @@ typedef struct KeyringProvideRecord
 typedef struct KeyringProviderXLRecord
 {
 	Oid	database_id;
-	Oid	tablespace_id;
 	off_t offset_in_file;
 	KeyringProvideRecord provider;
 } KeyringProviderXLRecord;
 
-extern List *GetAllKeyringProviders(Oid dbOid, Oid spcOid);
-extern GenericKeyring *GetKeyProviderByName(const char *provider_name, Oid dbOid, Oid spcOid);
-extern GenericKeyring *GetKeyProviderByID(int provider_id, Oid dbOid, Oid spcOid);
+extern List *GetAllKeyringProviders(Oid dbOid);
+extern GenericKeyring *GetKeyProviderByName(const char *provider_name, Oid dbOid);
+extern GenericKeyring *GetKeyProviderByID(int provider_id, Oid dbOid);
 extern ProviderType get_keyring_provider_from_typename(char *provider_type);
-extern void cleanup_key_provider_info(Oid databaseId, Oid tablespaceId);
+extern void cleanup_key_provider_info(Oid databaseId);
 extern void InitializeKeyProviderInfo(void);
 extern uint32 save_new_key_provider_info(KeyringProvideRecord *provider, 
 											Oid databaseId, Oid tablespaceId, 
 											bool write_xlog);
-extern uint32 copy_key_provider_info(KeyringProvideRecord* provider, 
-										Oid newdatabaseId, Oid newtablespaceId, 
-										bool write_xlog);
 extern uint32 redo_key_provider_info(KeyringProviderXLRecord *xlrec);
 
 extern bool ParseKeyringJSONOptions(ProviderType provider_type, void *out_opts,

--- a/src/include/catalog/tde_keyring.h
+++ b/src/include/catalog/tde_keyring.h
@@ -79,8 +79,7 @@ extern ProviderType get_keyring_provider_from_typename(char *provider_type);
 extern void cleanup_key_provider_info(Oid databaseId);
 extern void InitializeKeyProviderInfo(void);
 extern uint32 save_new_key_provider_info(KeyringProvideRecord *provider, 
-											Oid databaseId, Oid tablespaceId, 
-											bool write_xlog);
+											Oid databaseId, bool write_xlog);
 extern uint32 redo_key_provider_info(KeyringProviderXLRecord *xlrec);
 
 extern bool ParseKeyringJSONOptions(ProviderType provider_type, void *out_opts,

--- a/src/include/catalog/tde_principal_key.h
+++ b/src/include/catalog/tde_principal_key.h
@@ -62,9 +62,9 @@ extern void cleanup_principal_key_info(Oid databaseId);
 
 #ifndef FRONTEND
 extern LWLock *tde_lwlock_enc_keys(void);
-extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, Oid spcOid, LWLockMode lockMode);
+extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, LWLockMode lockMode);
 #else
-extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, Oid spcOid, void *lockMode);
+extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, void *lockMode);
 #endif
 
 extern bool save_principal_key_info(TDEPrincipalKeyInfo *principalKeyInfo);

--- a/src/include/catalog/tde_principal_key.h
+++ b/src/include/catalog/tde_principal_key.h
@@ -58,7 +58,7 @@ typedef struct XLogPrincipalKeyRotate
 #define SizeoOfXLogPrincipalKeyRotate	offsetof(XLogPrincipalKeyRotate, buff)
 
 extern void InitializePrincipalKeyInfo(void);
-extern void cleanup_principal_key_info(Oid databaseId, Oid tablespaceId);
+extern void cleanup_principal_key_info(Oid databaseId);
 
 #ifndef FRONTEND
 extern LWLock *tde_lwlock_enc_keys(void);

--- a/src/include/catalog/tde_principal_key.h
+++ b/src/include/catalog/tde_principal_key.h
@@ -33,7 +33,6 @@ typedef struct TDEPrincipalKeyId
 typedef struct TDEPrincipalKeyInfo
 {
 	Oid	databaseId;
-	Oid	tablespaceId;
 	Oid	userId;
 	Oid	keyringId;
 	struct timeval creationTime;

--- a/src/include/common/pg_tde_utils.h
+++ b/src/include/common/pg_tde_utils.h
@@ -19,6 +19,5 @@ extern List *get_all_tde_tables(void);
 extern int	get_tde_tables_count(void);
 #endif /* !FRONTEND */
 
-extern char *pg_tde_get_tde_file_dir(Oid dbOid, Oid spcOid);
 extern void pg_tde_set_globalspace_dir(const char *dir);
 #endif /* PG_TDE_UTILS_H */

--- a/src/include/encryption/enc_tde.h
+++ b/src/include/encryption/enc_tde.h
@@ -24,7 +24,7 @@ extern void
 
 /* A wrapper to encrypt a tuple before adding it to the buffer */
 extern OffsetNumber
-			PGTdePageAddItemExtended(RelFileLocator rel, Oid oid, BlockNumber bn, Page page,
+			PGTdePageAddItemExtended(RelFileLocator rel, BlockNumber bn, Page page,
 									 Item item,
 									 Size size,
 									 OffsetNumber offsetNumber,

--- a/src/include/encryption/enc_tde.h
+++ b/src/include/encryption/enc_tde.h
@@ -52,7 +52,7 @@ extern OffsetNumber
 		pg_tde_crypt(_iv_prefix, _start_offset, _data, _data_len, _out, _key, "ENCRYPT-PAGE-ITEM"); \
 	} while(0)
 
-extern void AesEncryptKey(const TDEPrincipalKey *principal_key, const RelFileLocator *rlocator, RelKeyData *rel_key_data, RelKeyData **p_enc_rel_key_data, size_t *enc_key_bytes);
-extern void AesDecryptKey(const TDEPrincipalKey *principal_key, const RelFileLocator *rlocator, RelKeyData **p_rel_key_data, RelKeyData *enc_rel_key_data, size_t *key_bytes);
+extern void AesEncryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, RelKeyData *rel_key_data, RelKeyData **p_enc_rel_key_data, size_t *enc_key_bytes);
+extern void AesDecryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, RelKeyData **p_rel_key_data, RelKeyData *enc_rel_key_data, size_t *key_bytes);
 
 #endif /* ENC_TDE_H */

--- a/src/include/pg_tde.h
+++ b/src/include/pg_tde.h
@@ -13,7 +13,6 @@
 typedef struct XLogExtensionInstall
 {
 	Oid	database_id;
-	Oid	tablespace_id;
 } XLogExtensionInstall;
 
 typedef void (*pg_tde_on_ext_install_callback) (int tde_tbl_count, XLogExtensionInstall *ext_info, bool redo, void *arg);

--- a/src/include/pg_tde.h
+++ b/src/include/pg_tde.h
@@ -8,6 +8,8 @@
 #ifndef PG_TDE_H
 #define PG_TDE_H
 
+#define PG_TDE_DATA_DIR	"pg_tde"
+
 typedef struct XLogExtensionInstall
 {
 	Oid	database_id;
@@ -19,4 +21,6 @@ typedef void (*pg_tde_on_ext_install_callback) (int tde_tbl_count, XLogExtension
 extern void on_ext_install(pg_tde_on_ext_install_callback function, void *arg);
 
 extern void extension_install_redo(XLogExtensionInstall *xlrec);
+
+extern void pg_tde_init_data_dir(void);
 #endif	/* PG_TDE_H */

--- a/src/include/pg_tde_defines.h
+++ b/src/include/pg_tde_defines.h
@@ -40,8 +40,8 @@
 #define pgstat_count_tdeheap_delete pgstat_count_heap_delete
 #define pgstat_count_tdeheap_insert pgstat_count_heap_insert
 
-#define TDE_PageAddItem(rel, oid, blkno, page, item, size, offsetNumber, overwrite, is_heap) \
-	PGTdePageAddItemExtended(rel, oid, blkno, page, item, size, offsetNumber, \
+#define TDE_PageAddItem(rel, blkno, page, item, size, offsetNumber, overwrite, is_heap) \
+	PGTdePageAddItemExtended(rel, blkno, page, item, size, offsetNumber, \
 						((overwrite) ? PAI_OVERWRITE : 0) | \
 						((is_heap) ? PAI_IS_HEAP : 0))
 

--- a/src/pg_tde.c
+++ b/src/pg_tde.c
@@ -138,7 +138,6 @@ pg_tde_extension_initialize(PG_FUNCTION_ARGS)
 	XLogExtensionInstall xlrec;
 
 	xlrec.database_id = MyDatabaseId;
-	xlrec.tablespace_id = MyDatabaseTableSpace;
 	run_extension_install_callbacks(&xlrec, false);
 
 	/*

--- a/src/pg_tde.c
+++ b/src/pg_tde.c
@@ -39,6 +39,8 @@
 #include "utils/percona.h"
 #endif
 
+#include <sys/stat.h>
+
 #define MAX_ON_INSTALLS 5
 
 PG_MODULE_MAGIC;
@@ -130,6 +132,8 @@ _PG_init(void)
 Datum
 pg_tde_extension_initialize(PG_FUNCTION_ARGS)
 {
+	pg_tde_init_data_dir();
+	
 	/* Initialize the TDE map */
 	XLogExtensionInstall xlrec;
 
@@ -172,6 +176,22 @@ on_ext_install(pg_tde_on_ext_install_callback function, void *arg)
 	on_ext_install_list[on_ext_install_index].arg = arg;
 
 	++on_ext_install_index;
+}
+
+/* Creates a tde directory for internal files if not exists */
+void
+pg_tde_init_data_dir(void)
+{
+	struct stat st;
+
+	if (stat(PG_TDE_DATA_DIR, &st) < 0)
+	{
+		if (MakePGDirectory(PG_TDE_DATA_DIR) < 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+						errmsg("could not create tde directory \"%s\": %m",
+							PG_TDE_DATA_DIR)));
+	}
 }
 
 /* ------------------

--- a/src/pg_tde_event_capture.c
+++ b/src/pg_tde_event_capture.c
@@ -21,7 +21,6 @@
 #include "commands/event_trigger.h"
 #include "common/pg_tde_utils.h"
 #include "pg_tde_event_capture.h"
-#include "commands/tablespace.h"
 #include "catalog/tde_principal_key.h"
 #include "miscadmin.h"
 #include "access/tableam.h"
@@ -148,11 +147,6 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 				tdeCurrentCreateEvent.relation = stmt->relation;
 			}
 		}
-
-		/*
-		 * TODO: also check for tablespace change, if current or new AM is
-		 * tde_heap!
-		 */
 
 		if (tdeCurrentCreateEvent.encryptMode)
 		{

--- a/src/pg_tde_event_capture.c
+++ b/src/pg_tde_event_capture.c
@@ -102,7 +102,6 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 	{
 		CreateStmt *stmt = (CreateStmt *) parsetree;
 		TDEPrincipalKey *principal_key;
-		Oid			tablespace_oid;
 
 		tdeCurrentCreateEvent.eventType = TDE_TABLE_CREATE_EVENT;
 		tdeCurrentCreateEvent.relation = stmt->relation;
@@ -118,10 +117,8 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 
 		if (tdeCurrentCreateEvent.encryptMode)
 		{
-			tablespace_oid = stmt->tablespacename != NULL ? get_tablespace_oid(stmt->tablespacename, false)
-				: MyDatabaseTableSpace;
 			LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
-			principal_key = GetPrincipalKey(MyDatabaseId, tablespace_oid, LW_SHARED);
+			principal_key = GetPrincipalKey(MyDatabaseId, LW_SHARED);
 			LWLockRelease(tde_lwlock_enc_keys());
 			if (principal_key == NULL)
 			{
@@ -162,11 +159,10 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 			TDEPrincipalKey * principal_key;
 			Oid		relationId = RangeVarGetRelid(stmt->relation, NoLock, true);
 			Relation	rel = table_open(relationId, lockmode);
-			Oid tablespace_oid = rel->rd_locator.spcOid;
 			table_close(rel, lockmode);
 
 			LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
-			principal_key = GetPrincipalKey(MyDatabaseId, tablespace_oid, LW_SHARED);
+			principal_key = GetPrincipalKey(MyDatabaseId, LW_SHARED);
 			LWLockRelease(tde_lwlock_enc_keys());
 			if (principal_key == NULL)
 			{

--- a/src/smgr/pg_tde_smgr.c
+++ b/src/smgr/pg_tde_smgr.c
@@ -51,7 +51,7 @@ tde_smgr_get_key(SMgrRelation reln, RelFileLocator* old_locator, bool can_create
 	}
 
 	LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
-	pk = GetPrincipalKey(reln->smgr_rlocator.locator.dbOid, reln->smgr_rlocator.locator.spcOid, LW_SHARED);
+	pk = GetPrincipalKey(reln->smgr_rlocator.locator.dbOid, LW_SHARED);
 	LWLockRelease(tde_lwlock_enc_keys());
 	if (pk == NULL)
 	{

--- a/src16/access/pg_tde_io.c
+++ b/src16/access/pg_tde_io.c
@@ -65,7 +65,7 @@ tdeheap_RelationPutHeapTuple(Relation relation,
 	pageHeader = BufferGetPage(buffer);
 
 	if (encrypt)
-		offnum = TDE_PageAddItem(relation->rd_locator, tuple->t_tableOid, BufferGetBlockNumber(buffer), pageHeader, (Item) tuple->t_data,
+		offnum = TDE_PageAddItem(relation->rd_locator, BufferGetBlockNumber(buffer), pageHeader, (Item) tuple->t_data,
 							tuple->t_len, InvalidOffsetNumber, false, true);
 	else
 		offnum = PageAddItem(pageHeader, (Item) tuple->t_data,

--- a/src16/access/pg_tde_rewrite.c
+++ b/src16/access/pg_tde_rewrite.c
@@ -711,7 +711,7 @@ raw_tdeheap_insert(RewriteState state, HeapTuple tup)
 	}
 
 	/* And now we can insert the tuple into the page */
-	newoff = TDE_PageAddItem(state->rs_new_rel->rd_locator, heaptup->t_tableOid, state->rs_blockno, page, (Item) heaptup->t_data, heaptup->t_len,
+	newoff = TDE_PageAddItem(state->rs_new_rel->rd_locator, state->rs_blockno, page, (Item) heaptup->t_data, heaptup->t_len,
 						 InvalidOffsetNumber, false, true);
 	if (newoff == InvalidOffsetNumber)
 		elog(ERROR, "failed to add tuple");

--- a/src16/access/pg_tdeam.c
+++ b/src16/access/pg_tdeam.c
@@ -9382,7 +9382,7 @@ tdeheap_xlog_insert(XLogReaderState *record)
 		HeapTupleHeaderSetCmin(htup, FirstCommandId);
 		htup->t_ctid = target_tid;
 
-		if (TDE_PageAddItem(target_locator, target_locator.spcOid, blkno, page, (Item) htup, newlen, xlrec->offnum,
+		if (TDE_PageAddItem(target_locator, blkno, page, (Item) htup, newlen, xlrec->offnum,
 						true, true) == InvalidOffsetNumber)
 			elog(PANIC, "failed to add tuple");
 
@@ -9526,7 +9526,7 @@ tdeheap_xlog_multi_insert(XLogReaderState *record)
 			ItemPointerSetBlockNumber(&htup->t_ctid, blkno);
 			ItemPointerSetOffsetNumber(&htup->t_ctid, offnum);
 
-			offnum = TDE_PageAddItem(rlocator, rlocator.spcOid, blkno, page, (Item) htup, newlen, offnum, true, true);
+			offnum = TDE_PageAddItem(rlocator, blkno, page, (Item) htup, newlen, offnum, true, true);
 			if (offnum == InvalidOffsetNumber)
 				elog(PANIC, "failed to add tuple");
 		}
@@ -9800,7 +9800,7 @@ tdeheap_xlog_update(XLogReaderState *record, bool hot_update)
 		/* Make sure there is no forward chain link in t_ctid */
 		htup->t_ctid = newtid;
 
-		offnum = TDE_PageAddItem(rlocator, rlocator.spcOid, newblk, page, (Item) htup, newlen, offnum, true, true);
+		offnum = TDE_PageAddItem(rlocator, newblk, page, (Item) htup, newlen, offnum, true, true);
 		if (offnum == InvalidOffsetNumber)
 			elog(PANIC, "failed to add tuple");
 

--- a/src17/access/pg_tde_io.c
+++ b/src17/access/pg_tde_io.c
@@ -64,7 +64,7 @@ tdeheap_RelationPutHeapTuple(Relation relation,
 	pageHeader = BufferGetPage(buffer);
 
 	if (encrypt)
-		offnum = TDE_PageAddItem(relation->rd_locator, tuple->t_tableOid, BufferGetBlockNumber(buffer), pageHeader, (Item) tuple->t_data,
+		offnum = TDE_PageAddItem(relation->rd_locator, BufferGetBlockNumber(buffer), pageHeader, (Item) tuple->t_data,
 							tuple->t_len, InvalidOffsetNumber, false, true);
 	else
 		offnum = PageAddItem(pageHeader, (Item) tuple->t_data,

--- a/src17/access/pg_tde_rewrite.c
+++ b/src17/access/pg_tde_rewrite.c
@@ -677,7 +677,7 @@ raw_tdeheap_insert(RewriteState state, HeapTuple tup)
 	}
 
 	/* And now we can insert the tuple into the page */
-	newoff = TDE_PageAddItem(state->rs_new_rel->rd_locator, heaptup->t_tableOid, state->rs_blockno, page, (Item) heaptup->t_data, heaptup->t_len,
+	newoff = TDE_PageAddItem(state->rs_new_rel->rd_locator, state->rs_blockno, page, (Item) heaptup->t_data, heaptup->t_len,
 						 InvalidOffsetNumber, false, true);
 	if (newoff == InvalidOffsetNumber)
 		elog(ERROR, "failed to add tuple");

--- a/src17/access/pg_tdeam.c
+++ b/src17/access/pg_tdeam.c
@@ -9282,7 +9282,7 @@ tdeheap_xlog_insert(XLogReaderState *record)
 		HeapTupleHeaderSetCmin(htup, FirstCommandId);
 		htup->t_ctid = target_tid;
 
-		if (TDE_PageAddItem(target_locator, target_locator.spcOid, blkno, page, (Item) htup, newlen, xlrec->offnum,
+		if (TDE_PageAddItem(target_locator, blkno, page, (Item) htup, newlen, xlrec->offnum,
 						true, true) == InvalidOffsetNumber)
 			elog(PANIC, "failed to add tuple");
 
@@ -9426,7 +9426,7 @@ tdeheap_xlog_multi_insert(XLogReaderState *record)
 			ItemPointerSetBlockNumber(&htup->t_ctid, blkno);
 			ItemPointerSetOffsetNumber(&htup->t_ctid, offnum);
 
-			offnum = TDE_PageAddItem(rlocator, rlocator.spcOid, blkno, page, (Item) htup, newlen, offnum, true, true);
+			offnum = TDE_PageAddItem(rlocator, blkno, page, (Item) htup, newlen, offnum, true, true);
 			if (offnum == InvalidOffsetNumber)
 				elog(PANIC, "failed to add tuple");
 		}
@@ -9700,7 +9700,7 @@ tdeheap_xlog_update(XLogReaderState *record, bool hot_update)
 		/* Make sure there is no forward chain link in t_ctid */
 		htup->t_ctid = newtid;
 
-		offnum = TDE_PageAddItem(rlocator, rlocator.spcOid, newblk, page, (Item) htup, newlen, offnum, true, true);
+		offnum = TDE_PageAddItem(rlocator, newblk, page, (Item) htup, newlen, offnum, true, true);
 		if (offnum == InvalidOffsetNumber)
 			elog(PANIC, "failed to add tuple");
 


### PR DESCRIPTION
This PR gets rid off table spaces references everywhere we can because having it really complicated things and made moving encrypted relation between table spaces really difficult. The main reason of the complexity is that a principal key and a keyring info are created and used in the scope entire database but different relations in the db can be located in different tablespaces. So we shouldn't use tablespaces there is a it (tablespace) belongs to the relation level.

That also means we shouldn't store keyring and internal key files in the database dir but move them to `PGDATA/pg_tde`. The files layout looks like that:
```
$ tree $PGDATA/pg_tde
...
├── pg_tde_16384_dat
├── pg_tde_16384_keyring
├── pg_tde_16384_map
├── pg_tde_607_dat
├── pg_tde_607_keyring
├── pg_tde_607_map
└── pg_tde_default_keyring_CHANGE_AND_REMOVE_IT
```

Fixes: PG-1209, PG-1196, PG-1208