### PR TITLE
PG-1225: Improve missing shared_preload_library error handling

### DIFF
--- a/src/pg_tde.c
+++ b/src/pg_tde.c
@@ -102,7 +102,8 @@ _PG_init(void)
 {
 	if (!process_shared_preload_libraries_in_progress)
 	{
-		elog(WARNING, "pg_tde can only be loaded at server startup. Restart required.");
+		elog(ERROR, "pg_tde can only be loaded at server startup. Restart required.");
+		return;
 	}
 
 #ifdef PERCONA_EXT


### PR DESCRIPTION
Change the severity of the error message and also return early to avoid a later fatal error and postgres closing the connection.

