### PR TITLE
PG-1246: Do not duplicate makefile object targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.so
 *.o
+*.frontend
 __pycache__
 
 /config.cache

--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,12 @@ src/libkmip/libkmip/src/kmip_memset.o
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
-override PG_CPPFLAGS += -I$(CURDIR)/src/include -I$(CURDIR)/src/libkmip/libkmip/include -I$(CURDIR)/src$(MAJORVERSION)/include -fPIC
+override PG_CPPFLAGS += -I$(CURDIR)/src/include -I$(CURDIR)/src/libkmip/libkmip/include -I$(CURDIR)/src$(MAJORVERSION)/include
 include $(PGXS)
 else
 subdir = contrib/pg_tde
 top_builddir = ../..
-override PG_CPPFLAGS += -I$(top_srcdir)/$(subdir)/src/include  -I$(top_srcdir)/$(subdir)/src/libkmip/libkmip/include -I$(top_srcdir)/$(subdir)/src$(MAJORVERSION)/include -fPIC
+override PG_CPPFLAGS += -I$(top_srcdir)/$(subdir)/src/include  -I$(top_srcdir)/$(subdir)/src/libkmip/libkmip/include -I$(top_srcdir)/$(subdir)/src$(MAJORVERSION)/include
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -1,20 +1,23 @@
 TDE_OBJS = \
- 	src/access/pg_tde_tdemap.o \
- 	src/access/pg_tde_xlog_encrypt.o \
- 	src/catalog/tde_global_space.o \
- 	src/catalog/tde_keyring.o \
- 	src/catalog/tde_keyring_parse_opts.o \
- 	src/catalog/tde_principal_key.o \
- 	src/common/pg_tde_utils.o \
- 	src/encryption/enc_aes.o \
- 	src/encryption/enc_tde.o \
- 	src/keyring/keyring_api.o \
- 	src/keyring/keyring_curl.o \
- 	src/keyring/keyring_file.o \
- 	src/keyring/keyring_vault.o \
-	src/keyring/keyring_kmip.o \
-	src/keyring/keyring_kmip_ereport.o \
-	src/libkmip/libkmip/src/kmip.o \
-	src/libkmip/libkmip/src/kmip_bio.o \
-	src/libkmip/libkmip/src/kmip_locate.o \
-	src/libkmip/libkmip/src/kmip_memset.o
+ 	src/access/pg_tde_tdemap.frontend \
+ 	src/access/pg_tde_xlog_encrypt.frontend \
+ 	src/catalog/tde_global_space.frontend \
+ 	src/catalog/tde_keyring.frontend \
+ 	src/catalog/tde_keyring_parse_opts.frontend \
+ 	src/catalog/tde_principal_key.frontend \
+ 	src/common/pg_tde_utils.frontend \
+ 	src/encryption/enc_aes.frontend \
+ 	src/encryption/enc_tde.frontend \
+ 	src/keyring/keyring_api.frontend \
+ 	src/keyring/keyring_curl.frontend \
+ 	src/keyring/keyring_file.frontend \
+ 	src/keyring/keyring_vault.frontend \
+	src/keyring/keyring_kmip.frontend \
+	src/keyring/keyring_kmip_ereport.frontend \
+	src/libkmip/libkmip/src/kmip.frontend \
+	src/libkmip/libkmip/src/kmip_bio.frontend \
+	src/libkmip/libkmip/src/kmip_locate.frontend \
+	src/libkmip/libkmip/src/kmip_memset.frontend
+
+%.frontend: %.c
+	$(CC) $(CPPFLAGS) -c $< -o $@


### PR DESCRIPTION
Issue: currently pg_tde with make wants to build the same object files twice. Once during the pg_waldump build with Makefile.tools, and once duriong the pg_tde build with Makefile.

As the make rulesystem sees that the object files are already built after the first time, it doesn't rebuild them, resulting in all kinds of issues, either incorrect pg_tde.so or a build failure.

Fix: rename the "frontend" built objects to <name>.frontend instead of <name>.o, and duplicate the build rule for them. This way the object files have a different name, and both will be built.

Note: the `-DFRONTEND` flag is not present in Makefile.tools, as it is currently added by pg_waldump. The postgres side still requires more refactoring so it feels like less of a hack, and during that, this file can be improved further.

