### PR TITLE
PG-1254, PG-1253, PG-1250: Improve diagnostic messages

### DIFF
--- a/expected/vault_v2_test.out
+++ b/expected/vault_v2_test.out
@@ -2,10 +2,25 @@
 \i sql/vault_v2_test.inc
 CREATE EXTENSION pg_tde;
 \getenv root_token ROOT_TOKEN
-SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
+SELECT pg_tde_add_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
  pg_tde_add_key_provider_vault_v2 
 ----------------------------------
                                 1
+(1 row)
+
+-- FAILS
+SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-incorrect');
+psql:sql/vault_v2_test.inc:7: ERROR:  Failed to store key on keyring. Please check the keyring configuration.
+CREATE TABLE test_enc(
+	  id SERIAL,
+	  k INTEGER DEFAULT '0' NOT NULL,
+	  PRIMARY KEY (id)
+	) USING :tde_am;
+psql:sql/vault_v2_test.inc:13: ERROR:  failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.
+SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
+ pg_tde_add_key_provider_vault_v2 
+----------------------------------
+                                2
 (1 row)
 
 SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');

--- a/expected/vault_v2_test_basic.out
+++ b/expected/vault_v2_test_basic.out
@@ -2,10 +2,25 @@
 \i sql/vault_v2_test.inc
 CREATE EXTENSION pg_tde;
 \getenv root_token ROOT_TOKEN
-SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
+SELECT pg_tde_add_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
  pg_tde_add_key_provider_vault_v2 
 ----------------------------------
                                 1
+(1 row)
+
+-- FAILS
+SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-incorrect');
+psql:sql/vault_v2_test.inc:7: ERROR:  Failed to store key on keyring. Please check the keyring configuration.
+CREATE TABLE test_enc(
+	  id SERIAL,
+	  k INTEGER DEFAULT '0' NOT NULL,
+	  PRIMARY KEY (id)
+	) USING :tde_am;
+psql:sql/vault_v2_test.inc:13: ERROR:  failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.
+SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
+ pg_tde_add_key_provider_vault_v2 
+----------------------------------
+                                2
 (1 row)
 
 SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');

--- a/sql/vault_v2_test.inc
+++ b/sql/vault_v2_test.inc
@@ -1,6 +1,17 @@
 CREATE EXTENSION pg_tde;
 
 \getenv root_token ROOT_TOKEN
+
+SELECT pg_tde_add_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
+-- FAILS
+SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-incorrect');
+
+CREATE TABLE test_enc(
+	  id SERIAL,
+	  k INTEGER DEFAULT '0' NOT NULL,
+	  PRIMARY KEY (id)
+	) USING :tde_am;
+
 SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
 SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');
 

--- a/src/catalog/tde_principal_key.c
+++ b/src/catalog/tde_principal_key.c
@@ -262,7 +262,7 @@ set_principal_key_with_keyring(const char *key_name, GenericKeyring *keyring,
 		keyInfo = load_latest_versioned_key_name(&principalKey->keyInfo, keyring, ensure_new_key);
 
 		if (keyInfo == NULL)
-			keyInfo = KeyringGenerateNewKeyAndStore(keyring, principalKey->keyInfo.keyId.versioned_name, INTERNAL_KEY_LEN, false);
+			keyInfo = KeyringGenerateNewKeyAndStore(keyring, principalKey->keyInfo.keyId.versioned_name, INTERNAL_KEY_LEN, true);
 
 		if (keyInfo == NULL)
 		{
@@ -424,7 +424,7 @@ RotatePrincipalKey(TDEPrincipalKey *current_key, const char *new_key_name, const
 	keyInfo = load_latest_versioned_key_name(&new_principal_key.keyInfo, keyring, ensure_new_key);
 
 	if (keyInfo == NULL)
-		keyInfo = KeyringGenerateNewKeyAndStore(keyring, new_principal_key.keyInfo.keyId.versioned_name, INTERNAL_KEY_LEN, false);
+		keyInfo = KeyringGenerateNewKeyAndStore(keyring, new_principal_key.keyInfo.keyId.versioned_name, INTERNAL_KEY_LEN, true);
 
 	if (keyInfo == NULL)
 	{
@@ -496,9 +496,10 @@ load_latest_versioned_key_name(TDEPrincipalKeyInfo *principal_key_info, GenericK
 		 */
 		if (kr_ret != KEYRING_CODE_SUCCESS && kr_ret != KEYRING_CODE_RESOURCE_NOT_AVAILABLE)
 		{
-			ereport(FATAL,
+			ereport(ERROR,
 					(errmsg("failed to retrieve principal key from keyring provider :\"%s\"", keyring->provider_name),
 					 errdetail("Error code: %d", kr_ret)));
+			return NULL;
 		}
 		if (keyInfo == NULL)
 		{
@@ -531,6 +532,7 @@ load_latest_versioned_key_name(TDEPrincipalKeyInfo *principal_key_info, GenericK
 		{
 			ereport(ERROR,
 					(errmsg("failed to retrieve principal key. %d versions already exist", MAX_PRINCIPAL_KEY_VERSION_NUM)));
+			return NULL;
 		}
 	}
 	return NULL;				/* Just to keep compiler quite */

--- a/src/keyring/keyring_api.c
+++ b/src/keyring/keyring_api.c
@@ -164,6 +164,8 @@ KeyringGenerateNewKeyAndStore(GenericKeyring *keyring, const char *key_name, uns
 	if (KeyringStoreKey(keyring, key, throw_error) != KEYRING_CODE_SUCCESS)
 	{
 		pfree(key);
+		ereport(ereport_level,
+			(errmsg("Failed to store key on keyring. Please check the keyring configuration.")));
 		return NULL;
 	}
 	return key;

--- a/src/pg_tde_event_capture.c
+++ b/src/pg_tde_event_capture.c
@@ -68,7 +68,6 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 	trigdata = (EventTriggerData *) fcinfo->context;
 	parsetree = trigdata->parsetree;
 
-	elog(LOG, "EVENT TRIGGER (%s) %s", trigdata->event, nodeToString(parsetree));
 	reset_current_tde_create_event();
 
 	if (IsA(parsetree, IndexStmt))


### PR DESCRIPTION
* Event triggers dumped a debug log message with the LOG level. This commit completely removes it, this is a debug functionality for development, it can be simply re-added temporarily during event trigger development
* Many, but not all FATAL messages are now ERROR messages. A few messages dealing with data corruption are still FATAL.
* Some of these also got a TODO comment, as it looks like those would result in a corrupted internal key file, resulting in data loss. These parts should be improved.
* Key generation on keyring was missing some error messages, and also displayed some of the messages as WARNING instead of ERROR. This is now all fixed, functions like pg_tde_set_principal key only display one specific error message explaining the problem.