### PR TITLE
PG-1243: add a hint about hint bits being dropped by alter table set …

### DIFF
--- a/documentation/docs/decrypt.md
+++ b/documentation/docs/decrypt.md
@@ -8,6 +8,9 @@ If you encrypted a table with the `tde_heap` or `tde_heap_basic` access method a
 ALTER TABLE mytable SET access method heap;
 ```
 
+!!! hint
+                                                                                                                                                                                                ALTER TABLE <tablename> SET access method removes the hint bits and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER.
+
 Check that the table is not encrypted:
 
 ```
@@ -25,6 +28,9 @@ The output returns `f` meaning that the table is no longer encrypted.
     ```
     
     Note that the indexes and WAL files will no longer be encrypted.
+    
+    !!! hint
+                                                                                                                                                                                                ALTER TABLE <tablename> SET access method removes the hint bits and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER.    
 
 ## Method 2. Create a new unencrypted table on the base of the encrypted one
 

--- a/documentation/docs/decrypt.md
+++ b/documentation/docs/decrypt.md
@@ -9,7 +9,7 @@ ALTER TABLE mytable SET access method heap;
 ```
 
 !!! hint
-                                                                                                                                                                                                ALTER TABLE <tablename> SET access method removes the hint bits and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER.
+                                                                                                                                                                                                ALTER TABLE <tablename> SET access method removes the [hint bits](https://wiki.postgresql.org/wiki/Hint_Bits) and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER.
 
 Check that the table is not encrypted:
 
@@ -30,7 +30,7 @@ The output returns `f` meaning that the table is no longer encrypted.
     Note that the indexes and WAL files will no longer be encrypted.
     
     !!! hint
-                                                                                                                                                                                                ALTER TABLE <tablename> SET access method removes the hint bits and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER.    
+                                                                                                                                                                                                ALTER TABLE <tablename> SET access method removes the [hint bits](https://wiki.postgresql.org/wiki/Hint_Bits) and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER.    
 
 ## Method 2. Create a new unencrypted table on the base of the encrypted one
 

--- a/documentation/docs/decrypt.md
+++ b/documentation/docs/decrypt.md
@@ -9,7 +9,10 @@ ALTER TABLE mytable SET access method heap;
 ```
 
 !!! hint
-                                                                                                                                                                                                ALTER TABLE <tablename> SET access method removes the [hint bits](https://wiki.postgresql.org/wiki/Hint_Bits) and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER.
+                                                                                                                                                                                                The ALTER TABLE <tablename> SET access method statement removes the [hint bits :octicons-link-external-16:](https://wiki.postgresql.org/wiki/Hint_Bits). This removal can lead to heavy writes to the database table, even if you're just reading from it. 
+                                                                                                                                                                                                A Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the ALTER command, run a simple "count(*)" on your tables:
+                                                                                                                                                                                                ```
+SELECT COUNT (*) FROM mytable;
 
 Check that the table is not encrypted:
 

--- a/documentation/docs/decrypt.md
+++ b/documentation/docs/decrypt.md
@@ -33,7 +33,10 @@ The output returns `f` meaning that the table is no longer encrypted.
     Note that the indexes and WAL files will no longer be encrypted.
     
     !!! hint
-                                                                                                                                                                                                ALTER TABLE <tablename> SET access method removes the [hint bits](https://wiki.postgresql.org/wiki/Hint_Bits) and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER.    
+                                                                                                                                                                                                Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the ALTER command, run a simple "count(*)" on your tables:
+                                                                                                                                                                                                
+                                                                                                                                                                                                ```
+SELECT COUNT(*) FROM mytable;
 
 ## Method 2. Create a new unencrypted table on the base of the encrypted one
 

--- a/documentation/docs/decrypt.md
+++ b/documentation/docs/decrypt.md
@@ -10,7 +10,7 @@ ALTER TABLE mytable SET access method heap;
 
 !!! hint
                                                                                                                                                                                                 The ALTER TABLE <tablename> SET access method statement removes the [hint bits :octicons-link-external-16:](https://wiki.postgresql.org/wiki/Hint_Bits). This removal can lead to heavy writes to the database table, even if you're just reading from it. 
-                                                                                                                                                                                                A Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the ALTER command, run a simple "count(*)" on your tables:
+                                                                                                                                                                                                Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the ALTER command, run a simple "count(*)" on your tables:
                                                                                                                                                                                                 ```
 SELECT COUNT(*) FROM mytable;
 

--- a/documentation/docs/decrypt.md
+++ b/documentation/docs/decrypt.md
@@ -12,7 +12,7 @@ ALTER TABLE mytable SET access method heap;
                                                                                                                                                                                                 The ALTER TABLE <tablename> SET access method statement removes the [hint bits :octicons-link-external-16:](https://wiki.postgresql.org/wiki/Hint_Bits). This removal can lead to heavy writes to the database table, even if you're just reading from it. 
                                                                                                                                                                                                 A Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the ALTER command, run a simple "count(*)" on your tables:
                                                                                                                                                                                                 ```
-SELECT COUNT (*) FROM mytable;
+SELECT COUNT(*) FROM mytable;
 
 Check that the table is not encrypted:
 

--- a/documentation/docs/test.md
+++ b/documentation/docs/test.md
@@ -49,7 +49,7 @@ Here's how to do it:
 
 !!! hint
 
-    ALTER TABLE <tablename> SET access method removes the hint bits and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER. 
+    ALTER TABLE <tablename> SET access method removes the [hint bits](https://wiki.postgresql.org/wiki/Hint_Bits) and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER. 
 
 !!! hint
 

--- a/documentation/docs/test.md
+++ b/documentation/docs/test.md
@@ -49,7 +49,10 @@ Here's how to do it:
 
 !!! hint
 
-    ALTER TABLE <tablename> SET access method removes the [hint bits](https://wiki.postgresql.org/wiki/Hint_Bits) and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER. 
+    Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the ALTER command, run a simple "count(*)" on your tables:
+                                                                                                                                                                                                
+                                                                                                                                                                                                ```
+SELECT COUNT(*) FROM mytable;
 
 !!! hint
 

--- a/documentation/docs/test.md
+++ b/documentation/docs/test.md
@@ -49,4 +49,8 @@ Here's how to do it:
 
 !!! hint
 
+    ALTER TABLE <tablename> SET access method removes the hint bits and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER. 
+
+!!! hint
+
     If you no longer wish to use `pg_tde` or wish to switch to using the `tde_heap_basic` access method, see how you can [decrypt your data](decrypt.md).


### PR DESCRIPTION
PG-1243

### Description

 ALTER TABLE <tablename> SET access method removes the hint bits and as such this can lead to heavy writes to the database table, even if you're just reading. A plain SELECT, count(*), or VACUUM on the entire table will check every tuple for visibility and set its hint bits. So we recommend you do a simple "count(*)" on your tables, after the ALTER.

### Links
https://wiki.postgresql.org/wiki/Hint_Bits

