### PR TITLE
Disable fail fast for Github CI matrixes

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -15,6 +15,7 @@ jobs:
   main:
     name: Main matrix
     strategy:
+      fail-fast: false
       matrix:
         pg_version: [17]
         os: [ubuntu-24.04]
@@ -32,6 +33,7 @@ jobs:
     name: ARM matrix
     if: github.event_name != 'pull_request'
     strategy:
+      fail-fast: false
       matrix:
         pg_version: [17]
         os: [ubuntu-24.04-arm]


### PR DESCRIPTION
It can be hard to debug multiple failures or from a quick glance to see what is broken due to the fail fast feature so to get a better picture of what actually went wrong we make sure to run all tasks of the matrix to finish even if one failed.