### PR TITLE
PG-1428: Relax existing key check on new principal key creation

### DIFF
--- a/src/catalog/tde_principal_key.c
+++ b/src/catalog/tde_principal_key.c
@@ -524,11 +524,6 @@ pg_tde_create_principal_key_internal(Oid providerOid,
 
 	key_info = KeyringGetKey(provider, key_name, &return_code);
 
-	if (return_code != KEYRING_CODE_SUCCESS)
-		ereport(ERROR,
-				errmsg("failed to retrieve principal key \"%s\" from key provider \"%s\"", key_name, provider_name),
-				errdetail("%s", KeyringErrorCodeToString(return_code)));
-
 	if (key_info != NULL)
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),


### PR DESCRIPTION
Previously first we checked that the lookup returns success, and then verified that we didn't get any result. This sounds good in theory, but in practice Akeyless reports an error on empty result sets for the locate operation.

This commit removes the return code check so that Akeyless works properly. KeyringGetKey returns NULL on every error return  path, so this definitely doesn't change any behavior with other providers.