### PR TITLE
PG-1879 Use new extension point to register custom AIO callback

### DIFF
--- a/src/smgr/pg_tde_smgr.c
+++ b/src/smgr/pg_tde_smgr.c
@@ -506,9 +506,10 @@ tde_mdstartreadv(PgAioHandle *ioh,
 				 SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 				 void **buffers, BlockNumber nblocks)
 {
-	/* Load key early: later we are in a critical section */
+	/* Uses a global variable to pass the relation key and IV */
 	aio_tdereln = (TDESMgrRelation *) reln;
 
+	/* Load key early: later we are in a critical section */
 	if (aio_tdereln->encryption_status == RELATION_KEY_NOT_AVAILABLE)
 	{
 		InternalKey *int_key = tde_smgr_get_key(&reln->smgr_rlocator);


### PR DESCRIPTION
Instead of patching the md.c callback's and adding our own we use something more like a preoper extension point which we have now added to Percona's fork of PostgreSQL. This new extension point allows registering a new type of AIO callback.

Now we have this new callback we can make sure to aonly register it for encrypted tables to slightly minimze the overhead of normal tables.