### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # pg_tde: Transparent Database Encryption for PostgreSQL
 
-The PostgreSQL extension provides data at rest encryption. It is currently in an experimental phase and is under active development. [We need your feedback!](https://github.com/percona/postgres/discussions)
+PostgreSQL extension that provides Transparent Data Encryption (TDE) to protect data at rest.
 
 ## Table of Contents
 


### PR DESCRIPTION
`pg_tde` became GA with the version 1.0 and thus it is no more in the experimental phase. The PR updates readme to reflect that.