### PR TITLE
Fix Github issue templates by removing invalid attribute

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -49,5 +49,4 @@ body:
   - type: markdown
     id: coc
     attributes:
-      label: Code of Conduct
       value: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/percona/community/blob/main/content/contribute/coc.md)

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -26,5 +26,4 @@ body:
   - type: markdown
     id: coc
     attributes:
-      label: Code of Conduct
       value: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/percona/community/blob/main/content/contribute/coc.md)


### PR DESCRIPTION
Makrdown blocks do not have the label attribute.