### PR TITLE
Remove github CODEOWNER for .github/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,3 @@
 # Order is important; the last matching pattern takes the most precedence.
 
 /documentation/ @nastena1606 @Andriciuc
-/.github/       @artemgavrilov


### PR DESCRIPTION
No single person is responsible for this, it's the whole team's responsibility to ensure CI works as expected.