### PR TITLE
Remove support for manually triggering CI workflows

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -9,7 +9,6 @@ on:
       - release-[0-9]+.[0-9]+*
     paths-ignore:
       - documentation/**
-  workflow_dispatch:
 
 jobs:
   main:

--- a/.github/workflows/pgindent.yml
+++ b/.github/workflows/pgindent.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     paths-ignore:
       - documentation/**
-  workflow_dispatch:
 
 env:
   pg_version: 18


### PR DESCRIPTION
~These just add noise to the config for not gain.~

New description:  I could not think of any reason we would want to do this and in either case it should either be an option for all or none.
