### PR TITLE
Reduce log spam from PostgreSQL in PSP test CI output

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -136,6 +136,7 @@ jobs:
         with:
           name: log-test-global-tde-${{ inputs.pg_version }}-${{ inputs.os }}-${{ inputs.compiler }}-${{ inputs.build_type }}
           path: |
+            pginst/postgresql.log
             postgres/contrib/*/log
             postgres/contrib/*/regression.diffs
             postgres/contrib/*/regression.out

--- a/ci_scripts/configure-global-tde.sh
+++ b/ci_scripts/configure-global-tde.sh
@@ -37,8 +37,8 @@ fi
 
 initdb -D "$PGDATA" $OPTS
 
-pg_ctl -D "$PGDATA" start -o "-p $PGPORT"
+pg_ctl -D "$PGDATA" start -o "-p $PGPORT" -l "$INSTALL_DIR/postgresql.log"
 
 psql postgres -f "$SCRIPT_DIR/tde_setup_global.sql" -v ON_ERROR_STOP=on
 
-pg_ctl -D "$PGDATA" restart -o "-p $PGPORT"
+pg_ctl -D "$PGDATA" restart -o "-p $PGPORT" -l "$INSTALL_DIR/postgresql.log"


### PR DESCRIPTION
Since PostgreSQL sent all log messages to stderr it could be hard to find which test case had failed, especially when the failing test was a TAP test. So let's instead write the output to a file which is included in the artifact generated when the tests fail.