### PR TITLE
Fail CI on code coverage report upload error

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,6 +62,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           verbose: true
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           working-directory: src
           files: "*.c.gcov"


### PR DESCRIPTION
We want to know if code coverage report wasn't uploaded. So let's fail CI in case of any errors.