### PR TITLE
Try to exclude fetools directory from Codecov report and update componenets

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,6 +7,7 @@ coverage:
         target: 90%
         threshold: 1%
         base: auto
+        paths: "!fetools/"
 comment:
   layout: "header, diff, components"
 component_management:


### PR DESCRIPTION
Including the `feutils` directory in the totals in the coverage report does not make too much sense since we only test the features relevant to `pg_tde`.

It is a bit tricky to test if a config change like this actually works but let's take stab at it.

Also update components to match current realities.