### PR TITLE
Use `VAULT_CACERT` env variable with OpenBao's client

### DIFF
--- a/ci_scripts/setup-keyring-servers.sh
+++ b/ci_scripts/setup-keyring-servers.sh
@@ -23,18 +23,17 @@ bao server -dev -dev-tls -dev-cluster-json="$CLUSTER_INFO" > /dev/null &
 sleep 10
 export VAULT_ROOT_TOKEN_FILE=$(mktemp)
 jq -r .root_token "$CLUSTER_INFO" > "$VAULT_ROOT_TOKEN_FILE"
-export VAULT_CACERT_FILE=$(jq -r .ca_cert_path "$CLUSTER_INFO")
+export VAULT_CACERT=$(jq -r .ca_cert_path "$CLUSTER_INFO")
 rm "$CLUSTER_INFO"
 
 ## We need to enable key/value version 1 engine for just for tests
-bao secrets enable -ca-cert="$VAULT_CACERT_FILE" -path=kv-v1 -version=1 kv
+bao secrets enable -path=kv-v1 -version=1 kv
+
+## Create a test namespace for the tests to test namespace support
+bao namespace create pgns
+bao secrets enable -ns=pgns -path=secret -description="Production Secrets" kv-v2
 
 if [ -v GITHUB_ACTIONS ]; then
     echo "VAULT_ROOT_TOKEN_FILE=$VAULT_ROOT_TOKEN_FILE" >> $GITHUB_ENV
-    echo "VAULT_CACERT_FILE=$VAULT_CACERT_FILE" >> $GITHUB_ENV
+    echo "VAULT_CACERT=$VAULT_CACERT" >> $GITHUB_ENV
 fi
-
-## Create a test namespace for the tests to test namespace support
-export VAULT_SKIP_VERIFY=true
-bao namespace create "pgns"
-bao secrets enable -ns=pgns -path=secret -description="Production Secrets" kv-v2

--- a/expected/vault_v2_test.out
+++ b/expected/vault_v2_test.out
@@ -1,6 +1,6 @@
 CREATE EXTENSION pg_tde;
 \getenv root_token_file VAULT_ROOT_TOKEN_FILE
-\getenv cacert_file VAULT_CACERT_FILE
+\getenv cacert_file VAULT_CACERT
 -- FAILS as mount path does not exist
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect', 'https://127.0.0.1:8200', 'DUMMY-MOUNT-PATH', :'root_token_file', :'cacert_file');
 ERROR:  failed to get mount info for "https://127.0.0.1:8200" at mountpoint "DUMMY-MOUNT-PATH" (HTTP 400)

--- a/sql/vault_v2_test.sql
+++ b/sql/vault_v2_test.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION pg_tde;
 
 \getenv root_token_file VAULT_ROOT_TOKEN_FILE
-\getenv cacert_file VAULT_CACERT_FILE
+\getenv cacert_file VAULT_CACERT
 
 -- FAILS as mount path does not exist
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect', 'https://127.0.0.1:8200', 'DUMMY-MOUNT-PATH', :'root_token_file', :'cacert_file');


### PR DESCRIPTION
Also rename `VAULT_CACERT_FILE` to `VAULT_CACERT` in our test suite since having two similarly named variables is just annoying.