### PR TITLE
Sync CI dependencies with the PGDG packages

### DIFF
--- a/ci_scripts/ubuntu-deps.sh
+++ b/ci_scripts/ubuntu-deps.sh
@@ -3,7 +3,9 @@
 set -e
 
 DEPS=(
-    # Build
+    # PostgreeSQL build dependencies
+    #
+    # Based on https://salsa.debian.org/postgresql/postgresql/-/blob/18/debian/control
     bison
     docbook-xml
     docbook-xsl
@@ -11,6 +13,7 @@ DEPS=(
     gettext
     libcurl4-openssl-dev
     libicu-dev
+    libipc-run-perl
     libkrb5-dev
     libldap2-dev
     liblz4-dev
@@ -37,12 +40,9 @@ DEPS=(
     xsltproc
     zlib1g-dev
     zstd
-    # Test
-    libipc-run-perl
-    # Test pg_tde
+    # pg_tde test dependencies
     libhttp-server-simple-perl
     lcov
-    # Run pgperltidy
     perltidy
 )
 


### PR DESCRIPTION
Try to keep use reasonably in sync with the Debian packages from PGDG. We do not use all these dependencies yet but maybe we should make sure we build with plpython, plperl, etc. But that is for another PR.

The list of build dependencies from the Debian package are the following:

```
autoconf
bison
clang
debhelper-compat
dh-exec
docbook-xml
docbook-xsl
dpkg-dev
flex
gdb
gettext
libcurl4-openssl-dev
libicu-dev
libio-pty-perl
libipc-run-perl
libkrb5-dev
libldap2-dev
liblz4-dev
libnuma-dev
libpam0g-dev
libperl-dev
libreadline-dev
libselinux1-dev
libssl-dev
libsystemd-dev
liburing-dev
libxml2-dev
libxml2-utils
libxslt1-dev
libzstd-dev
llvm-dev
lz4
mawk
openssl
perl
pkgconf
postgresql-common-dev
python3-dev
systemtap-sdt-dev
tcl-dev
tzdata
uuid-dev
xsltproc
zlib1g-dev
zstd
```

And a diff is the following:

```diff
--- ci_scripts/18.txt	2025-11-11 13:26:47.752212033 +0100
+++ ci_scripts/our.txt	2025-11-18 00:20:40.505125489 +0100
@@ -1,17 +1,10 @@
-autoconf
 bison
-clang
-debhelper-compat
-dh-exec
 docbook-xml
 docbook-xsl
-dpkg-dev
 flex
-gdb
 gettext
 libcurl4-openssl-dev
 libicu-dev
-libio-pty-perl
 libipc-run-perl
 libkrb5-dev
 libldap2-dev
@@ -28,17 +21,13 @@
 libxml2-utils
 libxslt1-dev
 libzstd-dev
-llvm-dev
 lz4
 mawk
-openssl
 perl
 pkgconf
-postgresql-common-dev
 python3-dev
 systemtap-sdt-dev
 tcl-dev
-tzdata
 uuid-dev
 xsltproc
 zlib1g-dev
```