### PR TITLE
Reduce diff against upstream in frontend tools

### DIFF
--- a/fetools/pg17/pg_basebackup/pg_basebackup.c
+++ b/fetools/pg17/pg_basebackup/pg_basebackup.c
@@ -47,7 +47,7 @@
 
 #define GLOBAL_DATA_TDE_OID 1664
 
-#define ERRCODE_DATA_CORRUPTED_BCP	"XX001"
+#define ERRCODE_DATA_CORRUPTED	"XX001"
 
 typedef struct TablespaceListCell
 {
@@ -2241,7 +2241,7 @@ BaseBackup(char *compression_algorithm, char *compression_detail,
 		const char *sqlstate = PQresultErrorField(res, PG_DIAG_SQLSTATE);
 
 		if (sqlstate &&
-			strcmp(sqlstate, ERRCODE_DATA_CORRUPTED_BCP) == 0)
+			strcmp(sqlstate, ERRCODE_DATA_CORRUPTED) == 0)
 		{
 			pg_log_error("checksum error occurred");
 			checksum_failure = true;

--- a/fetools/pg18/pg_basebackup/pg_basebackup.c
+++ b/fetools/pg18/pg_basebackup/pg_basebackup.c
@@ -47,7 +47,7 @@
 
 #define GLOBAL_DATA_TDE_OID 1664
 
-#define ERRCODE_DATA_CORRUPTED_BCP	"XX001"
+#define ERRCODE_DATA_CORRUPTED	"XX001"
 
 typedef struct TablespaceListCell
 {
@@ -2243,7 +2243,7 @@ BaseBackup(char *compression_algorithm, char *compression_detail,
 		const char *sqlstate = PQresultErrorField(res, PG_DIAG_SQLSTATE);
 
 		if (sqlstate &&
-			strcmp(sqlstate, ERRCODE_DATA_CORRUPTED_BCP) == 0)
+			strcmp(sqlstate, ERRCODE_DATA_CORRUPTED) == 0)
 		{
 			pg_log_error("checksum error occurred");
 			checksum_failure = true;


### PR DESCRIPTION
For unclear reasons this define was renamed in commit https://github.com/percona/postgres/commit/da899e0f32408d39e5b5e63d54d0cf08c76d6f43 and since it at least no longer seems to serve a purpose let's change the name back to the original to decrease the size of our diff against upstream.

@dAdAbird do you know the story behind it?