### PR TITLE
PG-1959: Workaround for incorrect Vault response

### DIFF
--- a/src/keyring/keyring_vault.c
+++ b/src/keyring/keyring_vault.c
@@ -370,31 +370,31 @@ validate(GenericKeyring *keyring)
 	json_error = parse_vault_mount_info(&parse, jlex);
 
 	if (json_error != JSON_SUCCESS)
-		ereport(ERROR,
+		ereport(WARNING,
 				errcode(ERRCODE_INVALID_JSON_TEXT),
 				errmsg("failed to parse mount info for \"%s\" at mountpoint \"%s\": %s",
 					   vault_keyring->vault_url, vault_keyring->vault_mount_path, json_errdetail(json_error, jlex)));
 
-	if (parse.type == NULL)
-		ereport(ERROR,
+	else if (parse.type == NULL)
+		ereport(WARNING,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("failed to parse mount info for \"%s\" at mountpoint \"%s\": missing type field",
 					   vault_keyring->vault_url, vault_keyring->vault_mount_path));
 
-	if (strcmp(parse.type, "kv") != 0)
+	else if (strcmp(parse.type, "kv") != 0)
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("vault mount at \"%s\" has unsupported engine type \"%s\"",
 					   vault_keyring->vault_mount_path, parse.type),
 				errhint("The only supported vault engine type is Key/Value version \"2\""));
 
-	if (parse.version == NULL)
+	else if (parse.version == NULL)
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("failed to parse mount info for \"%s\" at mountpoint \"%s\": missing version field",
 					   vault_keyring->vault_url, vault_keyring->vault_mount_path));
 
-	if (strcmp(parse.version, "2") != 0)
+	else if (strcmp(parse.version, "2") != 0)
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("vault mount at \"%s\" has unsupported Key/Value engine version \"%s\"",


### PR DESCRIPTION
Hashicorp Vault sends a different response when using namespaces compared to the "normal" responses for the mount path info: instead of all information available at the top level and inside the data subobject, it is only available inside data.

This commit modifies the parser to retrieve fields inside data instead, so it works in all situations.