### PR TITLE
PG-1805 PG-1806 Do not overwrite existing SMGR keys on WAL replay

### DIFF
--- a/ci_scripts/perl/PostgreSQL/Test/TdeCluster.pm
+++ b/ci_scripts/perl/PostgreSQL/Test/TdeCluster.pm
@@ -46,10 +46,8 @@ my %smgr_skip = (
 	  'pg_restore fail to restore _pg_tde schema on cluster which already has it',
 	'src/bin/scripts/t/020_createdb.pl' =>
 	  'tries to use FILE_COPY strategy for database creation with encrypted objects in the template',
-	'src/test/recovery/t/014_unlogged_reinit.pl' => 'invalid page in block',
 	'src/test/recovery/t/016_min_consistency.pl' =>
 	  'reads LSN directly from relation files',
-	'src/test/recovery/t/018_wal_optimize.pl' => 'invalid page in block',
 	'src/test/recovery/t/032_relfilenode_reuse.pl' => 'invalid page in block',
 	'src/test/recovery/t/043_no_contrecord_switch.pl' =>
 	  'uses write_wal to hack wal directly');

--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -88,13 +88,25 @@ static void pg_tde_write_one_map_entry(int fd, const TDEMapEntry *map_entry, off
 static int	pg_tde_file_header_write(const char *tde_filename, int fd, const TDESignedPrincipalKeyInfo *signed_key_info, off_t *bytes_written);
 static void pg_tde_initialize_map_entry(TDEMapEntry *map_entry, const TDEPrincipalKey *principal_key, const RelFileLocator *rlocator, const InternalKey *rel_key_data);
 static int	pg_tde_open_file_write(const char *tde_filename, const TDESignedPrincipalKeyInfo *signed_key_info, bool truncate, off_t *curr_pos);
-static void pg_tde_replace_key_map_entry(const RelFileLocator *rlocator, const InternalKey *rel_key_data, const TDEPrincipalKey *principal_key);
 
+/*
+ * Saves an internal key for the given relation. If replace_existing is false,
+ * the function will not overwrite an existing key for the relation, but will
+ * instead do nothing.
+ */
 void
-pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *rel_key_data)
+pg_tde_save_smgr_key(RelFileLocator rel,
+					 const InternalKey *rel_key_data,
+					 bool replace_existing)
 {
-	TDEPrincipalKey *principal_key;
+	char		file_path[MAXPGPATH];
+	bool		entry_already_exists;
+	int			fd;
 	LWLock	   *lock_pk = tde_lwlock_enc_keys();
+	TDEPrincipalKey *principal_key;
+	off_t		scan_offset;
+	TDESignedPrincipalKeyInfo signed_key_info;
+	off_t		write_offset;
 
 	LWLockAcquire(lock_pk, LW_EXCLUSIVE);
 	principal_key = GetPrincipalKey(rel.dbOid, LW_EXCLUSIVE);
@@ -105,7 +117,54 @@ pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *rel_key_data)
 				errhint("Use pg_tde_set_key_using_database_key_provider() or pg_tde_set_key_using_global_key_provider() to configure one."));
 	}
 
-	pg_tde_replace_key_map_entry(&rel, rel_key_data, principal_key);
+	pg_tde_set_db_file_path(rel.dbOid, file_path);
+	pg_tde_sign_principal_key_info(&signed_key_info, principal_key);
+
+	fd = pg_tde_open_file_write(file_path, &signed_key_info, false, &scan_offset);
+
+	/*
+	 * Look for an existing entry for the relation, also keep track of the
+	 * first free entry we find to be reused for the new key we're saving.
+	 */
+	entry_already_exists = false;
+	write_offset = 0;
+	while (1)
+	{
+		TDEMapEntry entry;
+		off_t		entry_offset = scan_offset;
+
+		if (!pg_tde_read_one_map_entry(fd, &entry, &scan_offset))
+		{
+			/*
+			 * If we're through the whole file without having found an empty
+			 * entry to overwrite, write at the end.
+			 */
+			if (write_offset == 0)
+				write_offset = entry_offset;
+			break;
+		}
+
+		if (entry.spcOid == rel.spcOid &&
+			entry.relNumber == rel.relNumber)
+		{
+			entry_already_exists = true;
+			write_offset = entry_offset;
+			break;
+		}
+
+		if (write_offset == 0 && entry.type == MAP_ENTRY_TYPE_EMPTY)
+			write_offset = entry_offset;
+	}
+
+	if (!entry_already_exists || replace_existing)
+	{
+		TDEMapEntry write_entry;
+
+		pg_tde_initialize_map_entry(&write_entry, principal_key, &rel, rel_key_data);
+		pg_tde_write_one_map_entry(fd, &write_entry, &write_offset, file_path);
+	}
+
+	CloseTransientFile(fd);
 	LWLockRelease(lock_pk);
 }
 
@@ -427,67 +486,6 @@ pg_tde_write_one_map_entry(int fd, const TDEMapEntry *map_entry, off_t *offset, 
 	}
 
 	*offset += bytes_written;
-}
-#endif
-
-#ifndef FRONTEND
-/*
- * The caller must hold an exclusive lock on the key file to avoid
- * concurrent in place updates leading to data conflicts.
- */
-void
-pg_tde_replace_key_map_entry(const RelFileLocator *rlocator, const InternalKey *rel_key_data, const TDEPrincipalKey *principal_key)
-{
-	char		db_map_path[MAXPGPATH];
-	int			map_fd;
-	off_t		curr_pos = 0;
-	off_t		write_pos = 0;
-	TDEMapEntry write_map_entry;
-	TDESignedPrincipalKeyInfo signed_key_Info;
-
-	Assert(rlocator);
-
-	pg_tde_set_db_file_path(rlocator->dbOid, db_map_path);
-
-	pg_tde_sign_principal_key_info(&signed_key_Info, principal_key);
-
-	/* Open and validate file for basic correctness. */
-	map_fd = pg_tde_open_file_write(db_map_path, &signed_key_Info, false, &curr_pos);
-
-	/*
-	 * Read until we find an empty slot. Otherwise, read until end. This seems
-	 * to be less frequent than vacuum. So let's keep this function here
-	 * rather than overloading the vacuum process.
-	 */
-	while (1)
-	{
-		TDEMapEntry read_map_entry;
-		off_t		prev_pos = curr_pos;
-
-		if (!pg_tde_read_one_map_entry(map_fd, &read_map_entry, &curr_pos))
-		{
-			if (write_pos == 0)
-				write_pos = prev_pos;
-			break;
-		}
-
-		if (read_map_entry.spcOid == rlocator->spcOid && read_map_entry.relNumber == rlocator->relNumber)
-		{
-			write_pos = prev_pos;
-			break;
-		}
-
-		if (write_pos == 0 && read_map_entry.type == MAP_ENTRY_TYPE_EMPTY)
-			write_pos = prev_pos;
-	}
-
-	/* Initialize map entry and encrypt key */
-	pg_tde_initialize_map_entry(&write_map_entry, principal_key, rlocator, rel_key_data);
-
-	/* Write the given entry at curr_pos; i.e. the free entry. */
-	pg_tde_write_one_map_entry(map_fd, &write_map_entry, &write_pos, db_map_path);
-
-	CloseTransientFile(map_fd);
 }
 #endif
 

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -6,7 +6,7 @@
 #include "access/pg_tde_keys_common.h"
 #include "encryption/enc_tde.h"
 
-extern void pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *key);
+extern void pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *key, bool replace_existing);
 extern bool pg_tde_has_smgr_key(RelFileLocator rel);
 extern InternalKey *pg_tde_get_smgr_key(RelFileLocator rel);
 extern void pg_tde_free_key_map_entry(RelFileLocator rel);

--- a/src/smgr/pg_tde_smgr.c
+++ b/src/smgr/pg_tde_smgr.c
@@ -110,7 +110,7 @@ tde_smgr_create_key(const RelFileLocatorBackend *smgr_rlocator)
 		tde_smgr_save_temp_key(&smgr_rlocator->locator, key);
 	else
 	{
-		pg_tde_save_smgr_key(smgr_rlocator->locator, key);
+		pg_tde_save_smgr_key(smgr_rlocator->locator, key, true);
 		tde_smgr_log_create_key(&smgr_rlocator->locator);
 	}
 
@@ -123,8 +123,7 @@ tde_smgr_create_key_redo(const RelFileLocator *rlocator)
 	InternalKey key;
 
 	pg_tde_generate_internal_key(&key, KeyLength);
-
-	pg_tde_save_smgr_key(*rlocator, &key);
+	pg_tde_save_smgr_key(*rlocator, &key, false);
 }
 
 static void

--- a/t/crash_recovery.pl
+++ b/t/crash_recovery.pl
@@ -127,6 +127,23 @@ PGTDE::poll_start($node);
 
 PGTDE::psql($node, 'postgres', "TABLE test_enc;");
 
+# Use an unlogged sequence owned by the encrypted table to ensure the sequence
+# is also encrypted. This is to verify that WAL replay doesn't overwrite the key
+# of an unlogged object's init fork, which would cause it to be unrecoverable
+# after crash recovery. We cannot use a regular relation in this test, because
+# their init forks is a 0 byte file so the wrong key being used isn't an issue
+# for them.
+PGTDE::psql($node, 'postgres',
+	"CREATE UNLOGGED SEQUENCE seq_unlogged OWNED BY test_enc.x;");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('seq_unlogged');");
+PGTDE::psql($node, 'postgres', "SELECT nextval('seq_unlogged');");
+$node->kill9;
+PGTDE::poll_start($node);
+
+# The sequence is now reset by crash recovery and will give us the same result
+# as it did above.
+PGTDE::psql($node, 'postgres', "SELECT nextval('seq_unlogged');");
+
 $node->stop;
 
 # Compare the expected and out file

--- a/t/expected/crash_recovery.out
+++ b/t/expected/crash_recovery.out
@@ -133,3 +133,22 @@ TABLE test_enc;
  8
 (8 rows)
 
+CREATE UNLOGGED SEQUENCE seq_unlogged OWNED BY test_enc.x;
+SELECT pg_tde_is_encrypted('seq_unlogged');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+SELECT nextval('seq_unlogged');
+ nextval 
+---------
+       1
+(1 row)
+
+SELECT nextval('seq_unlogged');
+ nextval 
+---------
+       1
+(1 row)
+


### PR DESCRIPTION
In some cases postgresql will replay the key creation record from wal during crash recovery while there is already encrypted data on disk. This would make the data unreadable since the key it was encrypted with would be gone.

~~Two questions for reviewer:~~
- ~~Do we need to do the search for key and addition of the new one in a single pass instead of two?~~
- ~~Should we add tests for this to the pg_tde test suite, or is it being tested in the PSP testsuite enough?~~

Another potential solution is to include the encrypted key data in the WAL record, but I'm worried that would open a can of worms my gut tells me we don't want to open.