### PR TITLE
PG-2252 Do not keep stale status for relations after smgr_close

### DIFF
--- a/src/smgr/pg_tde_smgr.c
+++ b/src/smgr/pg_tde_smgr.c
@@ -28,10 +28,10 @@ typedef enum TDEMgrRelationEncryptionStatus
 	RELATION_NOT_ENCRYPTED = 0,
 
 	/* This is an encrypted relation, and we have the key available. */
-	RELATION_KEY_AVAILABLE = 1,
+	RELATION_ENCRYPTED = 1,
 
-	/* This is an encrypted relation, but we haven't loaded the key yet. */
-	RELATION_KEY_NOT_AVAILABLE = 2,
+	/* Encryption status is unknown */
+	RELATION_ENCRYPTION_UNKNOWN = 2,
 } TDEMgrRelationEncryptionStatus;
 
 /*
@@ -197,6 +197,32 @@ tde_smgr_should_encrypt(const RelFileLocatorBackend *smgr_rlocator, RelFileLocat
 	return false;
 }
 
+/*
+ * Ensure the encryption status of the relation is known, and load the key if
+ * it is encrypted.
+ */
+static void
+tde_smgr_resolve_encryption_status(TDESMgrRelation *tdereln)
+{
+	InternalKey *key;
+
+	if (tdereln->encryption_status != RELATION_ENCRYPTION_UNKNOWN)
+		return;
+
+	key = tde_smgr_get_key(&tdereln->reln.smgr_rlocator);
+
+	if (key)
+	{
+		tdereln->relKey = *key;
+		tdereln->encryption_status = RELATION_ENCRYPTED;
+		pfree(key);
+	}
+	else
+	{
+		tdereln->encryption_status = RELATION_NOT_ENCRYPTED;
+	}
+}
+
 bool
 tde_smgr_rel_is_encrypted(SMgrRelation reln)
 {
@@ -205,8 +231,14 @@ tde_smgr_rel_is_encrypted(SMgrRelation reln)
 	if (reln->smgr_which != OurSMgrId)
 		return false;
 
-	return tdereln->encryption_status == RELATION_KEY_AVAILABLE ||
-		tdereln->encryption_status == RELATION_KEY_NOT_AVAILABLE;
+	/*
+	 * We don't want to actually try to load the key here as we want this
+	 * function to work even if the principal key is not available
+	 */
+	if (tdereln->encryption_status == RELATION_ENCRYPTION_UNKNOWN)
+		return tde_smgr_is_encrypted(&reln->smgr_rlocator);
+
+	return tdereln->encryption_status == RELATION_ENCRYPTED;
 }
 
 static void
@@ -214,6 +246,8 @@ tde_mdwritev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 			 const void **buffers, BlockNumber nblocks, bool skipFsync)
 {
 	TDESMgrRelation *tdereln = (TDESMgrRelation *) reln;
+
+	tde_smgr_resolve_encryption_status(tdereln);
 
 	if (tdereln->encryption_status == RELATION_NOT_ENCRYPTED)
 	{
@@ -223,15 +257,6 @@ tde_mdwritev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 	{
 		unsigned char *local_blocks = palloc_aligned(BLCKSZ * nblocks, PG_IO_ALIGN_SIZE, 0);
 		void	  **local_buffers = palloc_array(void *, nblocks);
-
-		if (tdereln->encryption_status == RELATION_KEY_NOT_AVAILABLE)
-		{
-			InternalKey *int_key = tde_smgr_get_key(&reln->smgr_rlocator);
-
-			tdereln->relKey = *int_key;
-			tdereln->encryption_status = RELATION_KEY_AVAILABLE;
-			pfree(int_key);
-		}
 
 		for (int i = 0; i < nblocks; ++i)
 		{
@@ -286,6 +311,8 @@ tde_mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 {
 	TDESMgrRelation *tdereln = (TDESMgrRelation *) reln;
 
+	tde_smgr_resolve_encryption_status(tdereln);
+
 	if (tdereln->encryption_status == RELATION_NOT_ENCRYPTED)
 	{
 		mdextend(reln, forknum, blocknum, buffer, skipFsync);
@@ -294,15 +321,6 @@ tde_mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 	{
 		unsigned char *local_blocks = palloc_aligned(BLCKSZ, PG_IO_ALIGN_SIZE, 0);
 		unsigned char iv[16];
-
-		if (tdereln->encryption_status == RELATION_KEY_NOT_AVAILABLE)
-		{
-			InternalKey *int_key = tde_smgr_get_key(&reln->smgr_rlocator);
-
-			tdereln->relKey = *int_key;
-			tdereln->encryption_status = RELATION_KEY_AVAILABLE;
-			pfree(int_key);
-		}
 
 		CalcBlockIv(forknum, blocknum, tdereln->relKey.base_iv, iv);
 
@@ -322,16 +340,10 @@ tde_mdreadv(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 
 	mdreadv(reln, forknum, blocknum, buffers, nblocks);
 
+	tde_smgr_resolve_encryption_status(tdereln);
+
 	if (tdereln->encryption_status == RELATION_NOT_ENCRYPTED)
 		return;
-	else if (tdereln->encryption_status == RELATION_KEY_NOT_AVAILABLE)
-	{
-		InternalKey *int_key = tde_smgr_get_key(&reln->smgr_rlocator);
-
-		tdereln->relKey = *int_key;
-		tdereln->encryption_status = RELATION_KEY_AVAILABLE;
-		pfree(int_key);
-	}
 
 	for (int i = 0; i < nblocks; ++i)
 	{
@@ -406,7 +418,7 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 
 	key = tde_smgr_create_key(&reln->smgr_rlocator);
 
-	tdereln->encryption_status = RELATION_KEY_AVAILABLE;
+	tdereln->encryption_status = RELATION_ENCRYPTED;
 	tdereln->relKey = *key;
 	pfree(key);
 }
@@ -425,14 +437,7 @@ tde_mdopen(SMgrRelation reln)
 
 	mdopen(reln);
 
-	if (tde_smgr_is_encrypted(&reln->smgr_rlocator))
-	{
-		tdereln->encryption_status = RELATION_KEY_NOT_AVAILABLE;
-	}
-	else
-	{
-		tdereln->encryption_status = RELATION_NOT_ENCRYPTED;
-	}
+	tdereln->encryption_status = RELATION_ENCRYPTION_UNKNOWN;
 }
 
 #if PG_VERSION_NUM >= 180000
@@ -548,16 +553,9 @@ tde_mdstartreadv(PgAioHandle *ioh,
 	TDESMgrRelation *tdereln = (TDESMgrRelation *) reln;
 
 	/* Load key in issuing backend: later we are in a critical section */
-	if (tdereln->encryption_status == RELATION_KEY_NOT_AVAILABLE)
-	{
-		InternalKey *int_key = tde_smgr_get_key(&reln->smgr_rlocator);
+	tde_smgr_resolve_encryption_status(tdereln);
 
-		tdereln->relKey = *int_key;
-		tdereln->encryption_status = RELATION_KEY_AVAILABLE;
-		pfree(int_key);
-	}
-
-	if (tdereln->encryption_status == RELATION_KEY_AVAILABLE)
+	if (tdereln->encryption_status == RELATION_ENCRYPTED)
 	{
 		/* Register decryption callback and connect key to IO handle */
 		tde_io_handle_keys[pgaio_io_get_id(ioh)] = tdereln->relKey;
@@ -579,12 +577,23 @@ const static PgAioHandleCallbacks aio_tde_readv_cb = {
 
 #endif
 
+static void
+tde_mdclose(SMgrRelation reln, ForkNumber forknum)
+{
+	TDESMgrRelation *tdereln = (TDESMgrRelation *) reln;
+
+	mdclose(reln, forknum);
+
+	if (forknum == MAIN_FORKNUM)
+		tdereln->encryption_status = RELATION_ENCRYPTION_UNKNOWN;
+}
+
 static const struct f_smgr tde_smgr = {
 	.name = "tde",
 	.smgr_init = mdinit,
 	.smgr_shutdown = NULL,
 	.smgr_open = tde_mdopen,
-	.smgr_close = mdclose,
+	.smgr_close = tde_mdclose,
 	.smgr_create = tde_mdcreate,
 	.smgr_exists = mdexists,
 	.smgr_unlink = tde_mdunlink,

--- a/t/expected/reuse_relfilenode_in_cache.out
+++ b/t/expected/reuse_relfilenode_in_cache.out
@@ -1,0 +1,37 @@
+CREATE EXTENSION pg_tde;
+SELECT pg_tde_add_global_key_provider_file('global-keyring', '/tmp/reuse_relfilenode_in_cache.per');
+ pg_tde_add_global_key_provider_file 
+-------------------------------------
+ 
+(1 row)
+
+SELECT pg_tde_create_key_using_global_key_provider('default-key', 'global-keyring');
+ pg_tde_create_key_using_global_key_provider 
+---------------------------------------------
+ 
+(1 row)
+
+SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'global-keyring');
+ pg_tde_set_default_key_using_global_key_provider 
+--------------------------------------------------
+ 
+(1 row)
+
+CREATE DATABASE conflict_db_template OID = 50000;
+CREATE EXTENSION pg_tde;
+CREATE TABLE large(id serial primary key, dataa text, datab text) USING tde_heap;
+INSERT INTO large(dataa, datab) SELECT g.i::text, 1 FROM generate_series(1, 4000) g(i);
+CREATE DATABASE conflict_db TEMPLATE conflict_db_template OID = 50001;
+CREATE EXTENSION pg_prewarm;
+CREATE TABLE replace_sb(data text);
+INSERT INTO replace_sb(data) SELECT random()::text FROM generate_series(1, 15000);
+UPDATE large SET datab = 1;
+DROP DATABASE conflict_db;
+CREATE DATABASE conflict_db TEMPLATE conflict_db_template OID = 50001;
+UPDATE large SET datab = 2;
+SELECT datab, count(*) FROM large GROUP BY 1 ORDER BY 1 LIMIT 10;
+ datab | count 
+-------+-------
+ 2     |  4000
+(1 row)
+

--- a/t/reuse_relfilenode_in_cache.pl
+++ b/t/reuse_relfilenode_in_cache.pl
@@ -1,0 +1,154 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use File::Basename;
+use Test::More;
+use lib 't';
+use pgtde;
+
+PGTDE::setup_files_dir(basename($0));
+
+unlink('/tmp/reuse_relfilenode_in_cache.per');
+
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', q[
+	full_page_writes = off
+	shared_buffers = 1MB
+	shared_preload_libraries = 'pg_tde'
+]);
+$node->start;
+
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION pg_tde;');
+PGTDE::psql($node, 'postgres',
+	"SELECT pg_tde_add_global_key_provider_file('global-keyring', '/tmp/reuse_relfilenode_in_cache.per');"
+);
+PGTDE::psql($node, 'postgres',
+	"SELECT pg_tde_create_key_using_global_key_provider('default-key', 'global-keyring');"
+);
+PGTDE::psql($node, 'postgres',
+	"SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'global-keyring');"
+);
+
+# Create a template with a table in it to ensure the relfilenodes get reused,
+# and fill the table with more data than can fit in shared buffers. We give the
+# template a fixed OID just to ensure there won't be a conflict with the OID of
+# the test database we create later.
+PGTDE::psql($node, 'postgres',
+	"CREATE DATABASE conflict_db_template OID = 50000;");
+PGTDE::psql($node, 'conflict_db_template', 'CREATE EXTENSION pg_tde;');
+PGTDE::psql($node, 'conflict_db_template',
+	"CREATE TABLE large(id serial primary key, dataa text, datab text) USING tde_heap;"
+);
+PGTDE::psql($node, 'conflict_db_template',
+	"INSERT INTO large(dataa, datab) SELECT g.i::text, 1 FROM generate_series(1, 4000) g(i);"
+);
+
+# Use a fixed OID for the test database so we can ensure it reuses the same
+# relfilenodes.
+PGTDE::psql($node, 'postgres',
+	"CREATE DATABASE conflict_db TEMPLATE conflict_db_template OID = 50001;");
+
+# Large table in postgres to fill shared_buffers and force eviction.
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION pg_prewarm;');
+PGTDE::psql($node, 'postgres', 'CREATE TABLE replace_sb(data text);');
+PGTDE::psql($node, 'postgres',
+	"INSERT INTO replace_sb(data) SELECT random()::text FROM generate_series(1, 15000);"
+);
+
+# Long-running session: holds SMgrRelation structs open across txn boundary.
+my $psql_timeout = IPC::Run::timer($PostgreSQL::Test::Utils::timeout_default);
+my %bg = (stdin => '', stdout => '', stderr => '');
+$bg{run} = IPC::Run::start(
+	[
+		'psql', '--no-psqlrc', '--no-align',
+		'--file' => '-',
+		'--dbname' => $node->connstr('postgres')
+	],
+	'<' => \$bg{stdin},
+	'>' => \$bg{stdout},
+	'2>' => \$bg{stderr},
+	$psql_timeout);
+
+send_query_and_wait(\%bg, q[BEGIN;], qr/BEGIN/m);
+
+# Dirty shared buffers, then evict through the long-running session.
+PGTDE::psql($node, 'conflict_db', "UPDATE large SET datab = 1;");
+cause_eviction(\%bg);
+
+# Recreate database with same OID and same relfilenodes. The reuse of cached
+# relfilenodes can happen without a DROP/CREATE database, but it's the easiest
+# way to reproduce.
+PGTDE::psql($node, 'postgres', "DROP DATABASE conflict_db;");
+PGTDE::psql($node, 'postgres',
+	"CREATE DATABASE conflict_db TEMPLATE conflict_db_template OID = 50001;");
+
+# Dirty buffers again and evict.
+PGTDE::psql($node, 'conflict_db', "UPDATE large SET datab = 2;");
+cause_eviction(\%bg);
+
+# Verify data is readable.
+PGTDE::psql($node, 'conflict_db',
+	"SELECT datab, count(*) FROM large GROUP BY 1 ORDER BY 1 LIMIT 10;");
+
+$bg{stdin} .= "\\q\n";
+$bg{run}->finish;
+$node->stop;
+
+# Compare the expected and out file
+my $compare = PGTDE->compare_results();
+
+is($compare, 0,
+	"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files."
+);
+
+done_testing();
+
+# These two functions are copied from postgresql's test/recovery/t/032_relfilenode_reuse.pl
+
+sub cause_eviction
+{
+	my ($psql) = @_;
+	send_query_and_wait(
+		$psql,
+		q[SELECT SUM(pg_prewarm(oid)) warmed_buffers FROM pg_class WHERE pg_relation_filenode(oid) != 0;],
+		qr/warmed_buffers/m);
+}
+
+sub send_query_and_wait
+{
+	my ($psql, $query, $untl) = @_;
+
+	$psql_timeout->reset();
+	$psql_timeout->start();
+
+	$$psql{stdin} .= $query;
+	$$psql{stdin} .= "\n";
+
+	$$psql{run}->pump_nb();
+	while (1)
+	{
+		last if $$psql{stdout} =~ /$untl/;
+
+		if ($psql_timeout->is_expired)
+		{
+			BAIL_OUT("aborting wait: program timed out\n"
+				  . "stream contents: >>$$psql{stdout}<<\n"
+				  . "pattern searched for: $untl\n");
+			return 0;
+		}
+		if (not $$psql{run}->pumpable())
+		{
+			BAIL_OUT("aborting wait: program died\n"
+				  . "stream contents: >>$$psql{stdout}<<\n"
+				  . "pattern searched for: $untl\n");
+			return 0;
+		}
+		$$psql{run}->pump();
+	}
+
+	$$psql{stdout} = '';
+	return 1;
+}


### PR DESCRIPTION
One backend might use its entry in the relcache for a relation that has been completely replaced by something else by another backend. This means that we no longer know the encryption status of this relation after smgr_close has been called.

This patch replaces the RELATION_KEY_NOT_AVAILABLE status with RELATION_ENCRYPTION_UNKNOWN and makes sure to lazily resolve the status on I/O.