### PR TITLE
Run pg_regress tests as a TAP test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ You can find the tests in the `sql` and `t` directories.
     meson install
     ```
 
-3. Start Percona Server for PostgreSQL
+3. Start OpenBao and OpenKMIP
 
 4. Run the tests using the following command:
 

--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,6 @@ MODULE_big = pg_tde
 EXTENSION = pg_tde
 DATA = pg_tde--2.0--2.1.sql pg_tde--1.0--2.0.sql pg_tde--1.0.sql
 
-REGRESS = \
-	access_control \
-	alter_index \
-	change_access_method \
-	create_database \
-	default_principal_key \
-	delete_principal_key \
-	insert_update_delete \
-	key_provider \
-	kmip_test \
-	partition_table \
-	pg_tde_is_encrypted \
-	recreate_storage \
-	relocate \
-	tablespace \
-	toast_decrypt \
-	vault_v2_test \
-	version
 TAP_TESTS = 1
 
 FETOOLS = fetools/pg$(MAJORVERSION)

--- a/ci_scripts/test.sh
+++ b/ci_scripts/test.sh
@@ -6,16 +6,8 @@ SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 
 cd "$SCRIPT_DIR/../../build"
 
-OPTS='--set shared_preload_libraries=pg_tde'
-
 if [ "$1" = sanitize ]; then
-    OPTS+=' --set max_stack_depth=8MB'
+    export PG_TEST_INITDB_EXTRA_OPTS='--set max_stack_depth=8MB'
 fi
 
-../pginst/bin/pg_ctl -D regress_install -l regress_install.log init -o "$OPTS"
-
-../pginst/bin/pg_ctl -D regress_install -l regress_install.log start
-
 meson test --timeout-multiplier=0 --print-errorlogs
-
-../pginst/bin/pg_ctl -D regress_install stop

--- a/meson.build
+++ b/meson.build
@@ -284,26 +284,6 @@ executable('pg_tde_waldump',
   link_with: [pg_tde_frontend, pg_tde_frontend_xlog],
 )
 
-regress_tests = [
-  'access_control',
-  'alter_index',
-  'change_access_method',
-  'create_database',
-  'default_principal_key',
-  'delete_principal_key',
-  'insert_update_delete',
-  'key_provider',
-  'kmip_test',
-  'partition_table',
-  'pg_tde_is_encrypted',
-  'recreate_storage',
-  'relocate',
-  'tablespace',
-  'toast_decrypt',
-  'vault_v2_test',
-  'version',
-]
-
 tap_tests = [
   't/2pc_replication.pl',
   't/basic.pl',
@@ -329,6 +309,7 @@ tap_tests = [
   't/pg_tde_upgrade.pl',
   't/pg_waldump_basic.pl',
   't/pg_waldump_fullpage.pl',
+  't/regress.pl',
   't/replication.pl',
   't/reuse_relfilenode_in_cache.pl',
   't/rotate_key.pl',
@@ -341,17 +322,6 @@ tap_tests = [
   't/wal_key_tli.pl',
 ]
 
-pg_regress = find_program('pg_regress', dirs: [pkglibdir / 'pgxs/src/test/regress'])
-
-test('regress',
-  pg_regress,
-  protocol: 'tap',
-  args: [
-    '--bindir', bindir,
-    '--inputdir', meson.current_source_dir(),
-  ] + regress_tests,
-)
-
 testwrap = files('testwrap')
 perl = find_program('perl')
 pg_regress = find_program('pg_regress', dirs: [pkglibdir / 'pgxs/src/test/regress'])
@@ -359,6 +329,7 @@ pg_regress = find_program('pg_regress', dirs: [pkglibdir / 'pgxs/src/test/regres
 env = environment()
 env.prepend('PATH', bindir)
 env.set('PG_REGRESS', pg_regress.full_path())
+env.set('top_builddir', meson.project_build_root())
 
 foreach test : tap_tests
   test(test,

--- a/t/regress.pl
+++ b/t/regress.pl
@@ -1,0 +1,53 @@
+use strict;
+use warnings FATAL => 'all';
+
+use PostgreSQL::Test::Cluster;
+
+my $orig_stdout;
+my $orig_stderr;
+
+BEGIN
+{
+	# PostgreSQL's test suite redirects stdout/sterr to a log file so we need
+	# to save them before the redirection happens.
+	open($orig_stdout, '>&', \*STDOUT) or die $!;
+	open($orig_stderr, '>&', \*STDERR) or die $!;
+}
+
+my @tests = qw(
+  access_control
+  alter_index
+  change_access_method
+  create_database
+  default_principal_key
+  delete_principal_key
+  insert_update_delete
+  key_provider
+  kmip_test
+  partition_table
+  pg_tde_is_encrypted
+  recreate_storage
+  relocate
+  tablespace
+  toast_decrypt
+  vault_v2_test
+  version
+);
+
+my $node = PostgreSQL::Test::Cluster->new('regress');
+$node->init;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
+$node->start;
+
+IPC::Run::run [
+	$ENV{PG_REGRESS},
+	'--host' => $node->host,
+	'--port' => $node->port,
+	'--outputdir' => $ENV{'top_builddir'} || '.',
+	@tests,
+  ],
+  '1>' => $orig_stdout,
+  '2>' => $orig_stderr
+  or exit $?;
+
+$node->stop;


### PR DESCRIPTION
To avoid having to start and stop a PostgreSQL instance every time we want to run the test suite we can wrap `pg_regress` in a TAP test which sets up a PostgreSQL cluster, start and stops it and deletes it after a successful test run.

While pg_regress can also run `initdb` we do it in Perl to match our other TAP tests can keep the number of tools a developer need to understand to a minimum.

Additionally we update `CONTRIBUTING.md` to add that people need OpenBao and PyKMIP running for the tests to pass.