### PR TITLE
Do not write TAP output files to source dir

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -119,7 +119,6 @@ jobs:
             build/regression.diffs
             build/results
             build/testrun
-            src/t/results
           retention-days: 3
 
   test-psp-with-tde:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,5 +83,4 @@ jobs:
             build/regression.diffs
             build/results
             build/testrun
-            src/t/results
           retention-days: 3

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -63,6 +63,5 @@ jobs:
             src/regression.diffs
             src/regression.out
             src/results
-            src/t/results
             src/tmp_check
           retention-days: 3

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -72,5 +72,4 @@ jobs:
             build/regression.diffs
             build/results
             build/testrun
-            src/t/results
           retention-days: 3

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ __pycache__
 # Generated subdirectories
 /log/
 /results/
-/t/results/
 /tmp_check/
 /regress_install/
 /regress_install.log

--- a/t/pgtde.pm
+++ b/t/pgtde.pm
@@ -3,6 +3,7 @@ package PGTDE;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 
+use Cwd qw(abs_path);
 use File::Basename;
 use File::Compare;
 use Test::More;
@@ -18,7 +19,12 @@ our $out_filename_with_path;
 our $debug_out_filename_with_path;
 
 my $expected_folder = "t/expected";
-my $results_folder = "t/results";
+my $results_folder;
+
+INIT
+{
+	$results_folder = "$PostgreSQL::Test::Utils::tmp_check/results";
+}
 
 sub psql
 {
@@ -95,8 +101,9 @@ sub setup_files_dir
 
 	my ($test_name) = $test_filename =~ /([^.]*)/;
 
-	$expected_filename_with_path = "${expected_folder}/${test_name}.out";
-	$out_filename_with_path = "${results_folder}/${test_name}.out";
+	$expected_filename_with_path =
+	  abs_path("${expected_folder}/${test_name}.out");
+	$out_filename_with_path = abs_path("${results_folder}/${test_name}.out");
 	$debug_out_filename_with_path =
 	  "${results_folder}/${test_name}.out.debug";
 


### PR DESCRIPTION
Now that we are using Meson it is even more annoying that some of our TAP tests write to `t/results`, so instead let's write them to `testrun/*/results`  which is in the source director on make and in the build directory on Meson.

And to make it more useful we make sure to output absolute paths on test failure so people easily can use diff.

@Naeem-Akhter @shahidullah79 @mohitj1988: would this change affect the QA workflows?