### PR TITLE
Prevent pg_upgrade tests from leaving delete_old_cluster.sh behind

### DIFF
--- a/t/pg_tde_upgrade.pl
+++ b/t/pg_tde_upgrade.pl
@@ -8,6 +8,10 @@ program_help_ok('pg_tde_upgrade');
 program_version_ok('pg_tde_upgrade');
 program_options_handling_ok('pg_tde_upgrade');
 
+# Make sure delete_old_cluster.{sh,bat} is not generated in the source
+# directory.
+chdir $PostgreSQL::Test::Utils::tmp_check;
+
 my $oldnotde = PostgreSQL::Test::Cluster->new('oldnotde');
 $oldnotde->init;
 $oldnotde->start;


### PR DESCRIPTION
Running pg_upgrade creates `delete_old_cluster.sh` which ends up in the current working directory, so make sure to change directory into the temporary directory used by the TAP test.