### PR TITLE
PG-2258: Create WAL principal key eagerly with default keys

### DIFF
--- a/src/catalog/tde_principal_key.c
+++ b/src/catalog/tde_principal_key.c
@@ -537,12 +537,29 @@ pg_tde_set_default_key_using_global_key_provider(PG_FUNCTION_ARGS)
 {
 	char	   *principal_key_name = PG_ARGISNULL(0) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
+	bool		need_server_key;
 
 	/* Using a global provider for the default encryption setting */
 	pg_tde_set_principal_key_internal(GLOBAL_DATA_TDE_OID,
 									  DEFAULT_DATA_TDE_OID,
 									  principal_key_name,
 									  provider_name);
+
+	/*
+	 * Ensure a server (WAL) principal key exists so that operations needing
+	 * it (e.g. pg_basebackup -E) work without first restarting the server.
+	 * Without this, the server key is only materialized lazily during the
+	 * next startup when WAL encryption is initialized.
+	 */
+	LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
+	need_server_key = (GetPrincipalKeyNoDefault(GLOBAL_DATA_TDE_OID, LW_SHARED) == NULL);
+	LWLockRelease(tde_lwlock_enc_keys());
+
+	if (need_server_key)
+		pg_tde_set_principal_key_internal(GLOBAL_DATA_TDE_OID,
+										  GLOBAL_DATA_TDE_OID,
+										  principal_key_name,
+										  provider_name);
 
 	PG_RETURN_VOID();
 }

--- a/t/basebackup_default_key.pl
+++ b/t/basebackup_default_key.pl
@@ -1,0 +1,63 @@
+#!/usr/bin/perl
+
+# Tests that pg_tde_basebackup -E works after setting just a default
+# principal key, without first restarting the primary. Before the fix,
+# the server (WAL) principal key was only materialized lazily on the
+# next server start, so taking an encrypted-WAL base backup of a freshly
+# configured cluster would fail with "could not find server principal key".
+
+use strict;
+use warnings;
+use File::Basename;
+use Test::More;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use PostgreSQL::Test::RecursiveCopy;
+
+my $keyfile = '/tmp/basebackup_default_key.per';
+unlink($keyfile);
+
+my $primary = PostgreSQL::Test::Cluster->new('primary');
+$primary->init(allows_streaming => 1);
+$primary->append_conf('postgresql.conf',
+	"shared_preload_libraries = 'pg_tde'");
+$primary->start;
+
+$primary->safe_psql('postgres', 'CREATE EXTENSION pg_tde;');
+$primary->safe_psql('postgres',
+	"SELECT pg_tde_add_global_key_provider_file('file-provider','$keyfile');"
+);
+$primary->safe_psql('postgres',
+	"SELECT pg_tde_create_key_using_global_key_provider('key1','file-provider');"
+);
+$primary->safe_psql('postgres',
+	"SELECT pg_tde_set_default_key_using_global_key_provider('key1','file-provider');"
+);
+
+my $server_key = $primary->safe_psql('postgres',
+	'SELECT key_name FROM pg_tde_server_key_info();');
+is($server_key, 'key1',
+	'server principal key auto-configured when default key is set');
+
+my $tempdir = PostgreSQL::Test::Utils::tempdir;
+my $backup_dir = "$tempdir/backup";
+
+mkdir $backup_dir or die "mkdir $backup_dir failed: $!";
+PostgreSQL::Test::RecursiveCopy::copypath($primary->data_dir . '/pg_tde',
+	$backup_dir . '/pg_tde');
+
+$primary->command_ok(
+	[
+		'pg_tde_basebackup', '-D',
+		$backup_dir, '-h',
+		$primary->host, '-p',
+		$primary->port, '--checkpoint',
+		'fast', '--no-sync',
+		'-E', '-X',
+		'stream',
+	],
+	'pg_tde_basebackup -E succeeds after only setting default key');
+
+$primary->stop;
+
+done_testing();


### PR DESCRIPTION
Previously we only created a global principal key on the first restart after creating a default key. This caused a basebackup taken immediately after it, without a restart between the two to fail.

The fix is simple, we create the global principal key eagerly together with the default key if it doesn't exists yet. This additionally results in a better "normal" workflow since we no longer create a new principal key during startup.