### PR TITLE
Add an assert to prevent memory leak from running AesInit() twice

### DIFF
--- a/src/encryption/enc_aes.c
+++ b/src/encryption/enc_aes.c
@@ -59,6 +59,9 @@ AesCbcInitCtx(const EVP_CIPHER *cipher, const char *name)
 void
 AesInit(void)
 {
+	/* Make sure we do not try to initialize crypto twice */
+	Assert(cipher_gcm_128 == NULL);
+
 	OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
 
 	cipher_gcm_128 = EVP_aes_128_gcm();


### PR DESCRIPTION
Since 0e6bccb721863e29a2004104a003a7fb3593582f we now allocate OpenSSL contexts in `AesInit()` which means calling it twice would leak memory. This means we should add an assert to prevent any caller starts doing so.