### PR TITLE
PG-2381 Fix migration with empty files and entries

### DIFF
--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -1030,8 +1030,11 @@ pg_tde_migrate_smgr_keys_file(void)
 		old_fd = pg_tde_open_file_basic(db_map_path, O_RDONLY | PG_BINARY, false);
 		pg_tde_file_header_read(db_map_path, old_fd, &fheader, &read_pos);
 
-		/* check if we have anything to do */
-		if (fheader.file_version == PG_TDE_SMGR_FILE_MAGIC)
+		/*
+		 * Check if we have anything to do. read_pos == 0 means the file had
+		 * no header because it was empty.
+		 */
+		if (read_pos == 0 || fheader.file_version == PG_TDE_SMGR_FILE_MAGIC)
 		{
 			CloseTransientFile(old_fd);
 			continue;

--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -972,6 +972,13 @@ map_from_disk_entry_v3(int fd, off_t *entry_offset, const TDEPrincipalKey *princ
 	if (!read_one_map_entry_v3(fd, &disk_entry, entry_offset))
 		return false;
 
+	/* Decrypting empty entries would fail, so just return an empty entry. */
+	if (disk_entry.type == MAP_ENTRY_TYPE_EMPTY)
+	{
+		memset(out, 0, sizeof(TDEMapEntry));
+		return true;
+	}
+
 	ikey_from_map_entry_v3(&disk_entry, principal_key, &key);
 
 	rloc.spcOid = disk_entry.spcOid;
@@ -1063,6 +1070,8 @@ pg_tde_migrate_smgr_keys_file(void)
 
 		while (read_map_entry(old_fd, &read_pos, principal_key, &new_entry))
 		{
+			if (new_entry.type == MAP_ENTRY_TYPE_EMPTY)
+				continue;
 			pg_tde_write_one_map_entry(new_fd, &new_entry, &write_pos, db_map_path);
 		}
 


### PR DESCRIPTION
The reproduction script in this issue surfaced two issues. One with an empty key file that was created by VACUUM FULL, and one with empty entries in the key file created by DROP TABLE. None of these issues had anything to do with pg_tde_upgrade but could be triggered even by only upgrading pg_tde without changing postgresql version at all.