### PR TITLE
Update release note with warning mention for pg_tde 2.2.0

### DIFF
--- a/documentation/docs/release-notes/release-notes-v2.2.0.md
+++ b/documentation/docs/release-notes/release-notes-v2.2.0.md
@@ -8,6 +8,9 @@ The `pg_tde` extension, provided by Percona, adds [Transparent Data Encryption (
 
 `pg_tde` now supports 256-bit AES encryption and introduces [`pg_tde_upgrade`](../command-line-tools/pg-tde-upgrade.md), a utility that simplifies the upgrades of encrypted clusters. For more details, see the [Changelog](#changelog).
 
+!!! warning
+    `pg_tde` 2.2.0 requires Percona Distribution for PostgreSQL 17.10 or 18.4. It is not compatible with earlier versions of the distribution.
+
 ### Documentation updates
 
 * The [Limitations of pg_tde](../index/tde-limitations.md) topic is updated to include a new section on known incompatibilities with Citus and TimescaleDB, and a clarification of the `ALTER DATABASE ... SET TABLESPACE` behavior, the command can be used but with restrictions when `pg_tde` is active.

--- a/documentation/docs/release-notes/release-notes-v2.2.0.md
+++ b/documentation/docs/release-notes/release-notes-v2.2.0.md
@@ -9,7 +9,7 @@ The `pg_tde` extension, provided by Percona, adds [Transparent Data Encryption (
 `pg_tde` now supports 256-bit AES encryption and introduces [`pg_tde_upgrade`](../command-line-tools/pg-tde-upgrade.md), a utility that simplifies the upgrades of encrypted clusters. For more details, see the [Changelog](#changelog).
 
 !!! warning
-    `pg_tde` 2.2.0 requires Percona Distribution for PostgreSQL 17.10 or 18.4. It is not compatible with earlier versions of the distribution.
+    `pg_tde` 2.2.0 is not compatible with Percona Distribution for PostgreSQL older than 17.10 or 18.4.
 
 ### Documentation updates
 


### PR DESCRIPTION
This PR adds to the release notes a warning regarding pg_tde 2.2.0 working only with 17.10 and 18.4