### PR TITLE
Create keys in temporary directories in idiomatic TAP tests

### DIFF
--- a/t/2pc_replication.pl
+++ b/t/2pc_replication.pl
@@ -30,8 +30,7 @@ sub configure_and_reload
 	return;
 }
 
-unlink('/tmp/pg_global_keyring.file');
-unlink('/tmp/pg_local_keyring.file');
+my $keydir = PostgreSQL::Test::Utils::tempdir;
 
 # Set up two nodes, which will alternately be primary and replication standby.
 
@@ -52,7 +51,7 @@ $node_london->start;
 # Create and enable tde extension
 $node_london->safe_psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 $node_london->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('global_key_provider', '/tmp/pg_global_keyring.file');"
+	"SELECT pg_tde_add_global_key_provider_file('global_key_provider', '$keydir/global.keys');"
 );
 $node_london->safe_psql('postgres',
 	"SELECT pg_tde_create_key_using_global_key_provider('global_test_key', 'global_key_provider');"
@@ -61,7 +60,7 @@ $node_london->safe_psql('postgres',
 	"SELECT pg_tde_set_server_key_using_global_key_provider('global_test_key', 'global_key_provider');"
 );
 $node_london->safe_psql('postgres',
-	"SELECT pg_tde_add_database_key_provider_file('local_key_provider', '/tmp/pg_local_keyring.file');"
+	"SELECT pg_tde_add_database_key_provider_file('local_key_provider', '$keydir/db.keys');"
 );
 $node_london->safe_psql('postgres',
 	"SELECT pg_tde_create_key_using_database_key_provider('local_test_key', 'local_key_provider');"

--- a/t/basebackup_default_key.pl
+++ b/t/basebackup_default_key.pl
@@ -8,14 +8,12 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use Test::More;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use PostgreSQL::Test::RecursiveCopy;
 
-my $keyfile = '/tmp/basebackup_default_key.per';
-unlink($keyfile);
+my $keydir = PostgreSQL::Test::Utils::tempdir;
 
 my $primary = PostgreSQL::Test::Cluster->new('primary');
 $primary->init(allows_streaming => 1);
@@ -25,7 +23,7 @@ $primary->start;
 
 $primary->safe_psql('postgres', 'CREATE EXTENSION pg_tde;');
 $primary->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-provider','$keyfile');"
+	"SELECT pg_tde_add_global_key_provider_file('file-provider','$keydir/global.keys');"
 );
 $primary->safe_psql('postgres',
 	"SELECT pg_tde_create_key_using_global_key_provider('key1','file-provider');"

--- a/t/pg_resetwal_basic.pl
+++ b/t/pg_resetwal_basic.pl
@@ -8,7 +8,7 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-unlink('/tmp/pg_resetwal_basic.per');
+my $keydir = PostgreSQL::Test::Utils::tempdir;
 
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
@@ -23,7 +23,7 @@ shared_preload_libraries = 'pg_tde'
 $node->start;
 $node->safe_psql('postgres', "CREATE EXTENSION pg_tde;");
 $node->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_resetwal_basic.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '$keydir/global.keys');"
 );
 $node->safe_psql('postgres',
 	"SELECT pg_tde_create_key_using_global_key_provider('server-key', 'file-keyring-wal');"

--- a/t/pg_resetwal_corrupted.pl
+++ b/t/pg_resetwal_corrupted.pl
@@ -10,7 +10,7 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-unlink('/tmp/pg_resetwal_corrupted.per');
+my $keydir = PostgreSQL::Test::Utils::tempdir;
 
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
@@ -24,7 +24,7 @@ shared_preload_libraries = 'pg_tde'
 $node->start;
 $node->safe_psql('postgres', "CREATE EXTENSION pg_tde;");
 $node->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_resetwal_corrupted.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '$keydir/global.keys');"
 );
 $node->safe_psql('postgres',
 	"SELECT pg_tde_create_key_using_global_key_provider('server-key', 'file-keyring-wal');"

--- a/t/pg_tde_upgrade.pl
+++ b/t/pg_tde_upgrade.pl
@@ -44,7 +44,7 @@ is($newnotde->safe_psql('postgres', "SELECT * FROM test_plain"),
 	"1\n2", 'can read tables');
 $newnotde->stop;
 
-unlink('/tmp/pg_tde_test_pg_upgrade.per');
+my $keydir = PostgreSQL::Test::Utils::tempdir;
 
 my $old = PostgreSQL::Test::Cluster->new('old');
 $old->init;
@@ -54,7 +54,7 @@ $old->safe_psql(
 	'postgres', "
 CREATE EXTENSION pg_tde;
 
-SELECT pg_tde_add_global_key_provider_file('file-vault', '/tmp/pg_tde_test_pg_upgrade.per');
+SELECT pg_tde_add_global_key_provider_file('file-vault', '$keydir/global.keys');
 SELECT pg_tde_create_key_using_global_key_provider('server-key', 'file-vault');
 SELECT pg_tde_set_key_using_global_key_provider('server-key', 'file-vault');
 SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-vault');

--- a/t/pg_waldump_basic.pl
+++ b/t/pg_waldump_basic.pl
@@ -7,7 +7,7 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-unlink('/tmp/pg_waldump_basic.per');
+my $keydir = PostgreSQL::Test::Utils::tempdir;
 
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
@@ -30,7 +30,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION pg_tde;");
 $node->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_waldump_basic.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '$keydir/global.keys');"
 );
 $node->safe_psql('postgres',
 	"SELECT pg_tde_create_key_using_global_key_provider('server-key', 'file-keyring-wal');"

--- a/t/pg_waldump_fullpage.pl
+++ b/t/pg_waldump_fullpage.pl
@@ -29,7 +29,7 @@ sub get_block_lsn
 	return ($lsn_hi, $lsn_lo);
 }
 
-unlink('/tmp/pg_waldump_fullpage.per');
+my $keydir = PostgreSQL::Test::Utils::tempdir;
 
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
@@ -44,7 +44,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION pg_tde;");
 $node->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_waldump_fullpage.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '$keydir/global.keys');"
 );
 $node->safe_psql('postgres',
 	"SELECT pg_tde_create_key_using_global_key_provider('server-key', 'file-keyring-wal');"

--- a/t/stream_rep.pl
+++ b/t/stream_rep.pl
@@ -9,6 +9,8 @@ use Test::More;
 use lib 't';
 use pgtde;
 
+my $keydir = PostgreSQL::Test::Utils::tempdir;
+
 # Initialize primary node
 my $node_primary = PostgreSQL::Test::Cluster->new('primary');
 # A specific role is created to perform some tests related to replication,
@@ -23,13 +25,11 @@ $node_primary->append_conf('postgresql.conf',
 $node_primary->start;
 my $backup_name = 'my_backup';
 
-unlink('/tmp/global_keyring.file');
-unlink('/tmp/local_keyring.file');
 # Create and enable tde extension
 $node_primary->safe_psql('postgres',
 	'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 $node_primary->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('global_key_provider', '/tmp/global_keyring.file');"
+	"SELECT pg_tde_add_global_key_provider_file('global_key_provider', '$keydir/global.keys');"
 );
 $node_primary->safe_psql('postgres',
 	"SELECT pg_tde_create_key_using_global_key_provider('global_test_key_stream', 'global_key_provider');"
@@ -38,7 +38,7 @@ $node_primary->safe_psql('postgres',
 	"SELECT pg_tde_set_server_key_using_global_key_provider('global_test_key_stream', 'global_key_provider');"
 );
 $node_primary->safe_psql('postgres',
-	"SELECT pg_tde_add_database_key_provider_file('local_key_provider', '/tmp/local_keyring.file');"
+	"SELECT pg_tde_add_database_key_provider_file('local_key_provider', '$keydir/db.keys');"
 );
 $node_primary->safe_psql('postgres',
 	"SELECT pg_tde_create_key_using_database_key_provider('local_test_key_stream', 'local_key_provider');"

--- a/t/wal_archiving.pl
+++ b/t/wal_archiving.pl
@@ -2,13 +2,9 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use Test::More;
-use lib 't';
-use pgtde;
+use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
-
-unlink('/tmp/wal_archiving.per');
 
 # Test CLI tools directly
 
@@ -19,6 +15,7 @@ if ($^O ne 'linux')
 	exit 0;
 }
 
+my $keydir = PostgreSQL::Test::Utils::tempdir;
 
 command_like(
 	[ 'pg_tde_archive_decrypt', '--help' ],
@@ -109,7 +106,7 @@ $primary->start;
 $primary->safe_psql('postgres', "CREATE EXTENSION pg_tde;");
 
 $primary->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('keyring', '/tmp/wal_archiving.per');"
+	"SELECT pg_tde_add_global_key_provider_file('keyring', '$keydir/global.keys');"
 );
 $primary->safe_psql('postgres',
 	"SELECT pg_tde_create_key_using_global_key_provider('server-key', 'keyring');"


### PR DESCRIPTION
In all our TAP tests which do not rely on using diff to assert anything we can just safely store our keys in a temporary directory which means we do not have to invent test specific names or call unlink.