### PR TITLE
PG-2399 Implement pg_checksums for encrypted tables

### DIFF
--- a/ci_scripts/perl/PostgreSQL/Test/TdeCluster.pm
+++ b/ci_scripts/perl/PostgreSQL/Test/TdeCluster.pm
@@ -26,10 +26,6 @@ my %smgr_skip = (
 	  'hacks relation files directly for scaffolding',
 	'src/bin/pg_amcheck/t/005_opclass_damage.pl' =>
 	  'investigate why this fails',
-	'src/bin/pg_basebackup/t/010_pg_basebackup.pl' =>
-	  'uses corrupt_page_checksum to directly hack relation files',
-	'src/bin/pg_checksums/t/002_actions.pl' =>
-	  'uses corrupt_page_checksum to directly hack relation files',
 	'src/bin/pg_dump/t/004_pg_dump_parallel.pl' =>
 	  'pg_restore fail to restore _pg_tde schema on cluster which already has it',
 	'src/bin/pg_dump/t/010_dump_connstr.pl' =>

--- a/ci_scripts/suppressions/lsan.supp
+++ b/ci_scripts/suppressions/lsan.supp
@@ -88,6 +88,3 @@ leak:HandleSlashCmds
 
 #pg_restore
 leak:RestoreArchive
-
-#pg_tde_checksums
-leak:get_principal_key_from_keyring

--- a/ci_scripts/suppressions/lsan.supp
+++ b/ci_scripts/suppressions/lsan.supp
@@ -88,3 +88,6 @@ leak:HandleSlashCmds
 
 #pg_restore
 leak:RestoreArchive
+
+#pg_tde_checksums
+leak:get_principal_key_from_keyring

--- a/documentation/docs/command-line-tools/cli-tools.md
+++ b/documentation/docs/command-line-tools/cli-tools.md
@@ -17,7 +17,7 @@ These tools are introduced exclusively by `pg_tde` to support key rotation and W
 
 These tools are modified versions of standard PostgreSQL utilities that include `pg_tde` support. You must use the `pg_tde_*` variants when working with encrypted WAL or tables:
 
-* [pg_tde_checksums](./pg-tde-checksums.md): verify data checksums (non-encrypted files only)
+* [pg_tde_checksums](./pg-tde-checksums.md): verify data checksums
 * [pg_tde_waldump](./pg-tde-waldump.md): inspect and decrypt WAL files
 * [pg_tde_basebackup](../how-to/backup-wal-enabled.md): create base backups that include encrypted data
 * pg_tde_resetwal: reset the WAL for clusters using `pg_tde`

--- a/documentation/docs/command-line-tools/pg-tde-checksums.md
+++ b/documentation/docs/command-line-tools/pg-tde-checksums.md
@@ -1,5 +1,3 @@
 # pg_tde_checksums
 
-[`pg_tde_checksums` :octicons-link-external-16:](https://www.postgresql.org/docs/current/app-pgchecksums.html) is a PostgreSQL command-line utility used to enable, disable, or verify data checksums on a PostgreSQL data directory. However, it cannot calculate checksums for encrypted files.
-
-Encrypted files are skipped, and this is reported in the output.
+[`pg_tde_checksums` :octicons-link-external-16:](https://www.postgresql.org/docs/current/app-pgchecksums.html) is a PostgreSQL command-line utility used to enable, disable, or verify data checksums on a PostgreSQL data directory. The tool is modified to add support for working with encrypted tables.

--- a/fetools/pg17/pg_checksums/pg_checksums.c
+++ b/fetools/pg17/pg_checksums/pg_checksums.c
@@ -197,7 +197,7 @@ scan_file(const char *fn, Oid spcOid, Oid dbOid, RelFileNumber relNumber, ForkNu
 	int			flags;
 	int64		blocks_written_in_file = 0;
 	RelFileLocator locator = {.spcOid = spcOid,.dbOid = dbOid,.relNumber = relNumber};
-	InternalKey *key;
+	InternalKey *key = NULL;
 
 	Assert(mode == PG_MODE_ENABLE ||
 		   mode == PG_MODE_CHECK);
@@ -210,7 +210,9 @@ scan_file(const char *fn, Oid spcOid, Oid dbOid, RelFileNumber relNumber, ForkNu
 
 	files_scanned++;
 
-	key = pg_tde_get_smgr_key(locator);
+	/* Unknown fork type so assume it is not encrypted */
+	if (forknum != InvalidForkNumber)
+		key = pg_tde_get_smgr_key(locator);
 
 	for (blockno = 0;; blockno++)
 	{

--- a/fetools/pg17/pg_checksums/pg_checksums.c
+++ b/fetools/pg17/pg_checksums/pg_checksums.c
@@ -131,14 +131,6 @@ pg_tde_init(const char *datadir)
 	pg_tde_fe_init(tdedir);
 }
 
-static bool
-is_pg_tde_encypted(Oid spcOid, Oid dbOid, RelFileNumber relNumber)
-{
-	RelFileLocator locator = {.spcOid = spcOid,.dbOid = dbOid,.relNumber = relNumber};
-
-	return pg_tde_has_smgr_key(locator);
-}
-
 /*
  * Report current progress status.  Parts borrowed from
  * src/bin/pg_basebackup/pg_basebackup.c.
@@ -196,7 +188,7 @@ skipfile(const char *fn)
 }
 
 static void
-scan_file(const char *fn, int segmentno)
+scan_file(const char *fn, Oid spcOid, Oid dbOid, RelFileNumber relNumber, ForkNumber forknum, int segmentno)
 {
 	PGIOAlignedBlock buf;
 	PageHeader	header = (PageHeader) buf.data;
@@ -204,6 +196,8 @@ scan_file(const char *fn, int segmentno)
 	BlockNumber blockno;
 	int			flags;
 	int64		blocks_written_in_file = 0;
+	RelFileLocator locator = {.spcOid = spcOid,.dbOid = dbOid,.relNumber = relNumber};
+	InternalKey *key;
 
 	Assert(mode == PG_MODE_ENABLE ||
 		   mode == PG_MODE_CHECK);
@@ -215,6 +209,8 @@ scan_file(const char *fn, int segmentno)
 		pg_fatal("could not open file \"%s\": %m", fn);
 
 	files_scanned++;
+
+	key = pg_tde_get_smgr_key(locator);
 
 	for (blockno = 0;; blockno++)
 	{
@@ -241,6 +237,10 @@ scan_file(const char *fn, int segmentno)
 		 * calculated using those counters may not reach 100%.
 		 */
 		current_size += r;
+
+		if (key)
+			tde_decrypt_smgr_block(key, forknum, blockno + segmentno * RELSEG_SIZE,
+								   (unsigned char *) buf.data, (unsigned char *) buf.data);
 
 		/* New pages have no checksum yet */
 		if (PageIsNew(buf.data))
@@ -273,6 +273,10 @@ scan_file(const char *fn, int segmentno)
 			/* Set checksum in page header */
 			header->pd_checksum = csum;
 
+			if (key)
+				tde_encrypt_smgr_block(key, forknum, blockno + segmentno * RELSEG_SIZE,
+									   (unsigned char *) buf.data, (unsigned char *) buf.data);
+
 			/* Seek back to beginning of block */
 			if (lseek(f, -BLCKSZ, SEEK_CUR) < 0)
 				pg_fatal("seek failed for block %u in file \"%s\": %m", blockno, fn);
@@ -293,6 +297,9 @@ scan_file(const char *fn, int segmentno)
 		if (showprogress)
 			progress_report(false);
 	}
+
+	if (key)
+		pfree(key);
 
 	if (verbose)
 	{
@@ -365,6 +372,7 @@ scan_directory(const char *basedir, const char *subdir, Oid tablespace, bool siz
 			char	   *forkpath,
 					   *segmentpath;
 			int			segmentno = 0;
+			ForkNumber	forknum = MAIN_FORKNUM;
 
 			if (skipfile(de->d_name))
 				continue;
@@ -396,21 +404,17 @@ scan_directory(const char *basedir, const char *subdir, Oid tablespace, bool siz
 				/* filenode not to be included */
 				continue;
 
-			dirsize += st.st_size;
+			if (forkpath != NULL)
+				forknum = forkname_to_number(forkpath);
 
-			if (is_pg_tde_encypted(tablespace, atooid(subdir), atooid(fnonly)))
-			{
-				if (!sizeonly)
-					pg_log_info("skipped pg_tde encrypted file \"%s\"", fn);
-				continue;
-			}
+			dirsize += st.st_size;
 
 			/*
 			 * No need to work on the file when calculating only the size of
 			 * the items in the data folder.
 			 */
 			if (!sizeonly)
-				scan_file(fn, segmentno);
+				scan_file(fn, tablespace, atooid(subdir), atooid(fnonly), forknum, segmentno);
 		}
 		else if (S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode))
 		{

--- a/fetools/pg18/pg_checksums/pg_checksums.c
+++ b/fetools/pg18/pg_checksums/pg_checksums.c
@@ -197,7 +197,7 @@ scan_file(const char *fn, Oid spcOid, Oid dbOid, RelFileNumber relNumber, ForkNu
 	int			flags;
 	int64		blocks_written_in_file = 0;
 	RelFileLocator locator = {.spcOid = spcOid,.dbOid = dbOid,.relNumber = relNumber};
-	InternalKey *key;
+	InternalKey *key = NULL;
 
 	Assert(mode == PG_MODE_ENABLE ||
 		   mode == PG_MODE_CHECK);
@@ -210,7 +210,9 @@ scan_file(const char *fn, Oid spcOid, Oid dbOid, RelFileNumber relNumber, ForkNu
 
 	files_scanned++;
 
-	key = pg_tde_get_smgr_key(locator);
+	/* Unknown fork type so assume it is not encrypted */
+	if (forknum != InvalidForkNumber)
+		key = pg_tde_get_smgr_key(locator);
 
 	for (blockno = 0;; blockno++)
 	{

--- a/fetools/pg18/pg_checksums/pg_checksums.c
+++ b/fetools/pg18/pg_checksums/pg_checksums.c
@@ -131,14 +131,6 @@ pg_tde_init(const char *datadir)
 	pg_tde_fe_init(tdedir);
 }
 
-static bool
-is_pg_tde_encypted(Oid spcOid, Oid dbOid, RelFileNumber relNumber)
-{
-	RelFileLocator locator = {.spcOid = spcOid,.dbOid = dbOid,.relNumber = relNumber};
-
-	return pg_tde_has_smgr_key(locator);
-}
-
 /*
  * Report current progress status.  Parts borrowed from
  * src/bin/pg_basebackup/pg_basebackup.c.
@@ -196,7 +188,7 @@ skipfile(const char *fn)
 }
 
 static void
-scan_file(const char *fn, int segmentno)
+scan_file(const char *fn, Oid spcOid, Oid dbOid, RelFileNumber relNumber, ForkNumber forknum, int segmentno)
 {
 	PGIOAlignedBlock buf;
 	PageHeader	header = (PageHeader) buf.data;
@@ -204,6 +196,8 @@ scan_file(const char *fn, int segmentno)
 	BlockNumber blockno;
 	int			flags;
 	int64		blocks_written_in_file = 0;
+	RelFileLocator locator = {.spcOid = spcOid,.dbOid = dbOid,.relNumber = relNumber};
+	InternalKey *key;
 
 	Assert(mode == PG_MODE_ENABLE ||
 		   mode == PG_MODE_CHECK);
@@ -215,6 +209,8 @@ scan_file(const char *fn, int segmentno)
 		pg_fatal("could not open file \"%s\": %m", fn);
 
 	files_scanned++;
+
+	key = pg_tde_get_smgr_key(locator);
 
 	for (blockno = 0;; blockno++)
 	{
@@ -241,6 +237,10 @@ scan_file(const char *fn, int segmentno)
 		 * calculated using those counters may not reach 100%.
 		 */
 		current_size += r;
+
+		if (key)
+			tde_decrypt_smgr_block(key, forknum, blockno + segmentno * RELSEG_SIZE,
+								   (unsigned char *) buf.data, (unsigned char *) buf.data);
 
 		/* New pages have no checksum yet */
 		if (PageIsNew(buf.data))
@@ -273,6 +273,10 @@ scan_file(const char *fn, int segmentno)
 			/* Set checksum in page header */
 			header->pd_checksum = csum;
 
+			if (key)
+				tde_encrypt_smgr_block(key, forknum, blockno + segmentno * RELSEG_SIZE,
+									   (unsigned char *) buf.data, (unsigned char *) buf.data);
+
 			/* Seek back to beginning of block */
 			if (lseek(f, -BLCKSZ, SEEK_CUR) < 0)
 				pg_fatal("seek failed for block %u in file \"%s\": %m", blockno, fn);
@@ -293,6 +297,9 @@ scan_file(const char *fn, int segmentno)
 		if (showprogress)
 			progress_report(false);
 	}
+
+	if (key)
+		pfree(key);
 
 	if (verbose)
 	{
@@ -365,6 +372,7 @@ scan_directory(const char *basedir, const char *subdir, Oid tablespace, bool siz
 			char	   *forkpath,
 					   *segmentpath;
 			int			segmentno = 0;
+			ForkNumber	forknum = MAIN_FORKNUM;
 
 			if (skipfile(de->d_name))
 				continue;
@@ -396,21 +404,17 @@ scan_directory(const char *basedir, const char *subdir, Oid tablespace, bool siz
 				/* filenode not to be included */
 				continue;
 
-			dirsize += st.st_size;
+			if (forkpath != NULL)
+				forknum = forkname_to_number(forkpath);
 
-			if (is_pg_tde_encypted(tablespace, atooid(subdir), atooid(fnonly)))
-			{
-				if (!sizeonly)
-					pg_log_info("skipped pg_tde encrypted file \"%s\"", fn);
-				continue;
-			}
+			dirsize += st.st_size;
 
 			/*
 			 * No need to work on the file when calculating only the size of
 			 * the items in the data folder.
 			 */
 			if (!sizeonly)
-				scan_file(fn, segmentno);
+				scan_file(fn, tablespace, atooid(subdir), atooid(fnonly), forknum, segmentno);
 		}
 		else if (S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode))
 		{

--- a/meson.build
+++ b/meson.build
@@ -307,6 +307,7 @@ tap_tests = [
   't/pg_rewind_pg_xlog_symlink.pl',
   't/pg_rewind_same_timeline.pl',
   't/pg_tde_change_key_provider.pl',
+  't/pg_tde_checksums.pl',
   't/pg_tde_upgrade.pl',
   't/pg_waldump_basic.pl',
   't/pg_waldump_fullpage.pl',

--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -891,6 +891,11 @@ pg_tde_get_smgr_key(RelFileLocator rel)
 				errhint("Create a new principal key and set it instead of the current one."));
 	}
 
+#ifdef FRONTEND
+	/* There is no principal key cache in the frontend. */
+	pfree(principal_key);
+#endif
+
 	return rel_key;
 }
 

--- a/src/encryption/enc_tde.c
+++ b/src/encryption/enc_tde.c
@@ -141,3 +141,67 @@ pg_tde_stream_crypt(const char *iv_prefix,
 		batch_no++;
 	}
 }
+
+/*
+ * The initialization vector of a block is its block number converted to a
+ * 128 bit big endian number plus the forknumber XOR the base IV of the
+ * relation file.
+ */
+static void
+CalcBlockIv(ForkNumber forknum, BlockNumber bn, const unsigned char *base_iv, unsigned char *iv)
+{
+	memset(iv, 0, 16);
+
+	/* The init fork is copied to the main fork so we must use the same IV */
+	iv[7] = forknum == INIT_FORKNUM ? MAIN_FORKNUM : forknum;
+
+	iv[12] = bn >> 24;
+	iv[13] = bn >> 16;
+	iv[14] = bn >> 8;
+	iv[15] = bn;
+
+	for (int i = 0; i < 16; i++)
+		iv[i] ^= base_iv[i];
+}
+
+void
+tde_decrypt_smgr_block(InternalKey *relKey, ForkNumber forknum, BlockNumber blocknum, const unsigned char *in, unsigned char *out)
+{
+	unsigned char iv[16];
+	bool		allZero = true;
+
+	/*
+	 * Detect unencrypted all-zero pages written by smgrzeroextend() by
+	 * looking at the first 32 bytes of the page.
+	 *
+	 * Not encrypting all-zero pages is safe because they are only written at
+	 * the end of the file when extending a table on disk so they tend to be
+	 * short lived plus they only leak a slightly more accurate table size
+	 * than one can glean from just the file size.
+	 */
+	for (int i = 0; i < 32; ++i)
+	{
+		if (in[i] != 0)
+		{
+			allZero = false;
+			break;
+		}
+	}
+
+	if (allZero)
+		return;
+
+	CalcBlockIv(forknum, blocknum, relKey->base_iv, iv);
+
+	AesDecrypt(relKey->key, relKey->key_len, iv, in, BLCKSZ, out);
+}
+
+void
+tde_encrypt_smgr_block(InternalKey *relKey, ForkNumber forknum, BlockNumber blocknum, const unsigned char *in, unsigned char *out)
+{
+	unsigned char iv[16];
+
+	CalcBlockIv(forknum, blocknum, relKey->base_iv, iv);
+
+	AesEncrypt(relKey->key, relKey->key_len, iv, in, BLCKSZ, out);
+}

--- a/src/include/encryption/enc_tde.h
+++ b/src/include/encryption/enc_tde.h
@@ -5,6 +5,9 @@
 #ifndef ENC_TDE_H
 #define ENC_TDE_H
 
+#include "common/relpath.h"
+#include "storage/block.h"
+
 #define TDE_KEY_NAME_LEN 256
 #define KEY_DATA_SIZE_128 16	/* 128 bit encryption */
 #define KEY_DATA_SIZE_256 32	/* 256 bit encryption */
@@ -38,4 +41,10 @@ extern void pg_tde_stream_crypt(const char *iv_prefix,
 								int key_len,
 								void **ctxPtr);
 
+extern void tde_decrypt_smgr_block(InternalKey *relKey, ForkNumber forknum,
+								   BlockNumber blocknum, const unsigned char *in,
+								   unsigned char *out);
+extern void tde_encrypt_smgr_block(InternalKey *relKey, ForkNumber forknum,
+								   BlockNumber blocknum, const unsigned char *in,
+								   unsigned char *out);
 #endif							/* ENC_TDE_H */

--- a/src/smgr/pg_tde_smgr.c
+++ b/src/smgr/pg_tde_smgr.c
@@ -77,7 +77,6 @@ static void tde_smgr_save_temp_key(const RelFileLocator *newrlocator, const Inte
 static InternalKey *tde_smgr_get_temp_key(const RelFileLocator *rel);
 static bool tde_smgr_has_temp_key(const RelFileLocator *rel);
 static void tde_smgr_delete_temp_key(const RelFileLocator *rel);
-static void CalcBlockIv(ForkNumber forknum, BlockNumber bn, const unsigned char *base_iv, unsigned char *iv);
 
 static void
 tde_smgr_log_create_key(const RelFileLocator *rlocator)
@@ -261,13 +260,10 @@ tde_mdwritev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 		for (int i = 0; i < nblocks; ++i)
 		{
 			BlockNumber bn = blocknum + i;
-			unsigned char iv[16];
 
 			local_buffers[i] = &local_blocks[i * BLCKSZ];
 
-			CalcBlockIv(forknum, bn, tdereln->relKey.base_iv, iv);
-
-			AesEncrypt(tdereln->relKey.key, tdereln->relKey.key_len, iv, ((unsigned char **) buffers)[i], BLCKSZ, local_buffers[i]);
+			tde_encrypt_smgr_block(&tdereln->relKey, forknum, bn, ((unsigned char **) buffers)[i], local_buffers[i]);
 		}
 
 		mdwritev(reln, forknum, blocknum,
@@ -320,11 +316,8 @@ tde_mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 	else
 	{
 		unsigned char *local_blocks = palloc_aligned(BLCKSZ, PG_IO_ALIGN_SIZE, 0);
-		unsigned char iv[16];
 
-		CalcBlockIv(forknum, blocknum, tdereln->relKey.base_iv, iv);
-
-		AesEncrypt(tdereln->relKey.key, tdereln->relKey.key_len, iv, ((unsigned char *) buffer), BLCKSZ, local_blocks);
+		tde_encrypt_smgr_block(&tdereln->relKey, forknum, blocknum, ((unsigned char *) buffer), local_blocks);
 
 		mdextend(reln, forknum, blocknum, local_blocks, skipFsync);
 
@@ -347,33 +340,10 @@ tde_mdreadv(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 
 	for (int i = 0; i < nblocks; ++i)
 	{
-		bool		allZero = true;
 		BlockNumber bn = blocknum + i;
-		unsigned char iv[16];
+		unsigned char *buf = ((unsigned char **) buffers)[i];
 
-		/*
-		 * Detect unencrypted all-zero pages written by smgrzeroextend() by
-		 * looking at the first 32 bytes of the page.
-		 *
-		 * Not encrypting all-zero pages is safe because they are only written
-		 * at the end of the file when extending a table on disk so they tend
-		 * to be short lived plus they only leak a slightly more accurate
-		 * table size than one can glean from just the file size.
-		 */
-		for (int j = 0; j < 32; ++j)
-		{
-			if (((char **) buffers)[i][j] != 0)
-			{
-				allZero = false;
-				break;
-			}
-		}
-		if (allZero)
-			continue;
-
-		CalcBlockIv(forknum, bn, tdereln->relKey.base_iv, iv);
-
-		AesDecrypt(tdereln->relKey.key, tdereln->relKey.key_len, iv, ((unsigned char **) buffers)[i], BLCKSZ, ((unsigned char **) buffers)[i]);
+		tde_decrypt_smgr_block(&tdereln->relKey, forknum, bn, buf, buf);
 	}
 }
 
@@ -511,36 +481,12 @@ tde_readv_complete(PgAioHandle *ioh, PgAioResult prior_result, uint8 cb_data)
 	{
 		Buffer		buf = io_data[buf_off];
 		char	   *buf_ptr = BufferGetBlock(buf);
-		bool		allZero = true;
 		BlockNumber bn = td->smgr.blockNum + buf_off;
-		unsigned char iv[16];
 
 		if (prior_result.result <= buf_off)
 			break;
 
-		/*
-		 * Detect unencrypted all-zero pages written by smgrzeroextend() by
-		 * looking at the first 32 bytes of the page.
-		 *
-		 * Not encrypting all-zero pages is safe because they are only written
-		 * at the end of the file when extending a table on disk so they tend
-		 * to be short lived plus they only leak a slightly more accurate
-		 * table size than one can glean from just the file size.
-		 */
-		for (int i = 0; i < 32; i++)
-		{
-			if (buf_ptr[i] != 0)
-			{
-				allZero = false;
-				break;
-			}
-		}
-		if (allZero)
-			continue;
-
-		CalcBlockIv(td->smgr.forkNum, bn, int_key->base_iv, iv);
-
-		AesDecrypt(int_key->key, int_key->key_len, iv, ((unsigned char *) buf_ptr), BLCKSZ, ((unsigned char *) buf_ptr));
+		tde_decrypt_smgr_block(int_key, td->smgr.forkNum, bn, ((unsigned char *) buf_ptr), ((unsigned char *) buf_ptr));
 	}
 
 	return prior_result;
@@ -715,26 +661,4 @@ tde_smgr_delete_temp_key(const RelFileLocator *rel)
 {
 	Assert(TempRelKeys);
 	hash_search(TempRelKeys, rel, HASH_REMOVE, NULL);
-}
-
-/*
- * The intialization vector of a block is its block number conmverted to a
- * 128 bit big endian number plus the forknumber XOR the base IV of the
- * relation file.
- */
-static void
-CalcBlockIv(ForkNumber forknum, BlockNumber bn, const unsigned char *base_iv, unsigned char *iv)
-{
-	memset(iv, 0, 16);
-
-	/* The init fork is copied to the main fork so we must use the same IV */
-	iv[7] = forknum == INIT_FORKNUM ? MAIN_FORKNUM : forknum;
-
-	iv[12] = bn >> 24;
-	iv[13] = bn >> 16;
-	iv[14] = bn >> 8;
-	iv[15] = bn;
-
-	for (int i = 0; i < 16; i++)
-		iv[i] ^= base_iv[i];
 }

--- a/t/pg_tde_checksums.pl
+++ b/t/pg_tde_checksums.pl
@@ -1,0 +1,56 @@
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $stderr;
+
+my $keydir = PostgreSQL::Test::Utils::tempdir;
+
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init(no_data_checksums => 1);
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
+$node->start;
+$node->safe_psql(
+	'postgres', "
+CREATE EXTENSION pg_tde;
+SELECT pg_tde_add_database_key_provider_file('db', '$keydir/db.keys');
+SELECT pg_tde_create_key_using_database_key_provider('server-key', 'db');
+SELECT pg_tde_set_key_using_database_key_provider('server-key', 'db');
+
+CREATE TABLE test_enc (k int, PRIMARY KEY (k)) USING tde_heap;
+INSERT INTO test_enc (k) VALUES (1), (2);
+");
+
+my $relfile =
+  $node->safe_psql('postgres', "SELECT pg_relation_filepath('test_enc')");
+
+$node->stop;
+
+command_ok([ 'pg_tde_checksums', '--no-sync', '--enable', $node->data_dir ],
+	'can enable checksums for encrypted tables');
+
+$node->start;
+is($node->safe_psql('postgres', 'SELECT * FROM test_enc'),
+	"1\n2", 'can still read the table');
+$node->stop;
+
+$node->corrupt_page_checksum($relfile, 0);
+
+$node->command_checks_all(
+	[ 'pg_tde_checksums', '--check', $node->data_dir ],
+	1,
+	[qr/Bad checksums:.*1/],
+	[qr/checksum verification failed/],
+	'fails checksum validation after we corrupted a block');
+
+$node->start;
+(undef, undef, $stderr) = $node->psql('postgres', 'SELECT * FROM test_enc'),
+  like(
+	$stderr,
+	qr/ERROR:  invalid page in block 0 of relation/,
+	'cannot read the table after corrupting a block');
+$node->stop;
+
+done_testing();


### PR DESCRIPTION
There was nothing fundamental in our design which prevented  `pg_tde_checksunms` from validating or enabling checksums on encrypted tables, so do that instead of just skipping them.

Also enable two previously skipped PostgreSQL tests, one which now passes and the other which always seems to have passed.