### PR TITLE
Use the latest version of OpenBao in our CI

### DIFF
--- a/ci_scripts/ubuntu-deps.sh
+++ b/ci_scripts/ubuntu-deps.sh
@@ -53,12 +53,14 @@ sudo apt-get install -y ${DEPS[@]}
 sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
 # Cosmian KMS
-wget https://package.cosmian.com/kms/5.21.0/deb/$(dpkg --print-architecture)/non-fips/static/cosmian-kms-server-non-fips-static-openssl_5.21.0_$(dpkg --print-architecture).deb
-sudo dpkg -i cosmian-kms-server-non-fips-static-openssl_5.21.0_$(dpkg --print-architecture).deb
+COSMIAN_VERSION=5.21.0
+wget https://package.cosmian.com/kms/$COSMIAN_VERSION/deb/$(dpkg --print-architecture)/non-fips/static/cosmian-kms-server-non-fips-static-openssl_${COSMIAN_VERSION}_$(dpkg --print-architecture).deb
+sudo dpkg -i cosmian-kms-server-non-fips-static-openssl_${COSMIAN_VERSION}_$(dpkg --print-architecture).deb
 # .deb ships binary + bundled legacy.so as 0500 root:root; CI runner is non-root.
 sudo chmod 0755 /usr/sbin/cosmian_kms
 sudo chmod 0755 /usr/local/cosmian/lib/ossl-modules/legacy.so
 
 # OpenBao
-wget https://github.com/openbao/openbao/releases/download/v2.4.3/bao_2.4.3_linux_$(dpkg --print-architecture).deb
-sudo dpkg -i bao_2.4.3_linux_$(dpkg --print-architecture).deb
+OPENBAO_VERSION=2.4.3
+wget https://github.com/openbao/openbao/releases/download/v$OPENBAO_VERSION/bao_${OPENBAO_VERSION}_linux_$(dpkg --print-architecture).deb
+sudo dpkg -i bao_${OPENBAO_VERSION}_linux_$(dpkg --print-architecture).deb

--- a/ci_scripts/ubuntu-deps.sh
+++ b/ci_scripts/ubuntu-deps.sh
@@ -61,6 +61,6 @@ sudo chmod 0755 /usr/sbin/cosmian_kms
 sudo chmod 0755 /usr/local/cosmian/lib/ossl-modules/legacy.so
 
 # OpenBao
-OPENBAO_VERSION=2.4.3
-wget https://github.com/openbao/openbao/releases/download/v$OPENBAO_VERSION/bao_${OPENBAO_VERSION}_linux_$(dpkg --print-architecture).deb
-sudo dpkg -i bao_${OPENBAO_VERSION}_linux_$(dpkg --print-architecture).deb
+OPENBAO_VERSION=2.5.4
+wget https://github.com/openbao/openbao/releases/download/v$OPENBAO_VERSION/openbao_${OPENBAO_VERSION}_linux_$(dpkg --print-architecture).deb
+sudo dpkg -i openbao_${OPENBAO_VERSION}_linux_$(dpkg --print-architecture).deb


### PR DESCRIPTION
Also reduces some duplication in the script installing OpenBao. We may want to switch to using their APT repo, but for now just upgrade to the latest.