### PR TITLE
pg_rewind: ensure WAL segments restored from archive

### DIFF
--- a/fetools/pg18/pg_rewind/filemap.c
+++ b/fetools/pg18/pg_rewind/filemap.c
@@ -87,7 +87,6 @@ typedef struct keepwal_entry
 
 
 static keepwal_hash *keepwal = NULL;
-static bool keepwal_entry_exists(const char *path);
 
 static int	final_filemap_cmp(const void *a, const void *b);
 
@@ -263,7 +262,7 @@ keepwal_add_entry(const char *path)
 }
 
 /* Return true if file is marked as not to be removed, false otherwise */
-static bool
+bool
 keepwal_entry_exists(const char *path)
 {
 	return keepwal_lookup(keepwal, path) != NULL;

--- a/fetools/pg18/pg_rewind/filemap.h
+++ b/fetools/pg18/pg_rewind/filemap.h
@@ -116,7 +116,11 @@ extern void print_filemap(filemap_t *filemap);
 
 extern void keepwal_init(void);
 extern void keepwal_add_entry(const char *path);
+extern bool keepwal_entry_exists(const char *path);
 
 extern bool path_rlocator(const char *path, RelFileLocator *rlocator, unsigned int *segNo);
+
+extern void ensure_tde_archive_wal(void);
+extern void archive_wal_segments_add_entry(const char *path);
 
 #endif							/* FILEMAP_H */

--- a/fetools/pg18/pg_rewind/parsexlog.c
+++ b/fetools/pg18/pg_rewind/parsexlog.c
@@ -349,8 +349,14 @@ SimpleXLogPageRead(XLogReaderState *xlogreader, XLogRecPtr targetPagePtr,
 			if (xlogreadfd < 0)
 				return -1;
 			else
+			{
+				char		xlogdirfname[MAXPGPATH];
+
+				snprintf(xlogdirfname, MAXPGPATH, XLOGDIR "/%s", xlogfname);
+				archive_wal_segments_add_entry(xlogdirfname);
 				pg_log_debug("using file \"%s\" restored from archive",
 							 xlogfpath);
+			}
 		}
 	}
 

--- a/fetools/pg18/pg_rewind/pg_rewind.c
+++ b/fetools/pg18/pg_rewind/pg_rewind.c
@@ -665,6 +665,9 @@ perform_rewind(filemap_t *filemap, rewind_source *source,
 
 	close_target_file();
 
+	/* ensure (re-encrypt) destination's segments recovered from the archive */
+	ensure_tde_archive_wal();
+
 	fetch_tde_dir();
 
 	progress_report(true);

--- a/fetools/pg18/pg_rewind/tde_ops.c
+++ b/fetools/pg18/pg_rewind/tde_ops.c
@@ -5,6 +5,7 @@
 #include "access/xlog_internal.h"
 #include "catalog/pg_tablespace_d.h"
 #include "common/file_perm.h"
+#include "fe_utils/simple_list.h"
 
 #include "file_ops.h"
 #include "filemap.h"
@@ -19,6 +20,18 @@
 
 static void copy_dir(const char *src, const char *dst);
 static void create_tde_tmp_dir(void);
+
+/*
+ * Keep track of destination segments retrieved from the archive. These files
+ * might need re-encryption.
+ */
+SimplePtrList archive_wal_segments = {NULL, NULL};
+
+void
+archive_wal_segments_add_entry(const char *path)
+{
+	simple_ptr_list_append(&archive_wal_segments, pstrdup(path));
+}
 
 typedef struct
 {
@@ -138,6 +151,33 @@ flush_current_tde_rel_key(void)
 	pfree(current_tde_file.source_key);
 	pfree(current_tde_file.target_key);
 	memset(&current_tde_file, 0, sizeof(current_tde_file));
+}
+
+void
+ensure_tde_archive_wal()
+{
+	SimplePtrListCell *cell;
+
+	for (cell = archive_wal_segments.head; cell; cell = cell->next)
+	{
+		char		wal_path[MAXPGPATH];
+		char	   *segpath = (char *) cell->ptr;
+
+		/*
+		 * All "kept" WAL segments are re-encrypted regardless of their
+		 * origins. Hence, by this time, such files have already been
+		 * processed, and additional re-encryption will corrupt them.
+		 */
+		if (keepwal_entry_exists(segpath))
+			continue;
+
+		snprintf(wal_path, sizeof(wal_path), "%s/%s", datadir_target, segpath);
+
+		if (access(wal_path, F_OK) != 0)
+			continue;
+
+		ensure_tde_wal_seg(segpath);
+	}
 }
 
 void

--- a/meson.build
+++ b/meson.build
@@ -303,6 +303,7 @@ tap_tests = [
   't/pg_rewind_enc_copy_blocks.pl',
   't/pg_rewind_enc_ext_tablespace.pl',
   't/pg_rewind_enc_fsm.pl',
+  't/pg_rewind_enc_keep_archive_wal.pl',
   't/pg_rewind_enc_keep_wal_seg.pl',
   't/pg_rewind_enc_unchanged_rel.pl',
   't/pg_rewind_extrafiles.pl',

--- a/t/pg_rewind_enc_keep_archive_wal.pl
+++ b/t/pg_rewind_enc_keep_archive_wal.pl
@@ -1,0 +1,160 @@
+# Make pg_rewind to restore some target's WAL segments from the archive and then
+# use some of those segments for the rewinded recovery.
+# The test checks if such segments are properly re-encrypted, hence no
+# "invalid magic number" in server log during recovery after the rewind.
+#
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Utils;
+use Test::More;
+use File::Copy;
+
+use FindBin;
+use lib $FindBin::RealBin;
+
+use RewindTest;
+
+sub wait_for_archive
+{
+	my $archive_dir = shift;
+	my $node = shift;
+
+	my $wal = $node->safe_psql('postgres',
+		"SELECT pg_walfile_name(pg_current_wal_lsn())");
+	$wal =~ s/\s+//g;
+
+	print "Waiting for WAL archive: $wal\n";
+
+	my $timeout = 180;
+	while ($timeout > 0)
+	{
+		if (-f "$archive_dir/$wal")
+		{
+			print "WAL archived: $wal\n";
+			return 1;
+		}
+
+		sleep 1;
+		$timeout--;
+	}
+
+	print "WAL not archived: $wal\n";
+	return 0;
+}
+
+my $extra_conf;
+my $cluster_name = 'local';
+
+my $tempdir = PostgreSQL::Test::Utils::tempdir_short();
+
+my $archive_dir = $tempdir . '/archive';
+
+
+mkdir($archive_dir) || die "mkdir $archive_dir: $!";
+
+push @$extra_conf, "wal_keep_size=0";
+push @$extra_conf, "archive_mode=on";
+push @$extra_conf, "archive_timeout=10s";
+push @$extra_conf,
+  "archive_command='pg_tde_archive_decrypt %f %p \"cp %%p $archive_dir/%%f\"'";
+push @$extra_conf,
+  "restore_command='pg_tde_restore_encrypt %f %p \"cp $archive_dir/%%f %%p\"'";
+
+RewindTest::setup_cluster($cluster_name, [], $extra_conf);
+RewindTest::start_primary();
+
+my $node_primary = $RewindTest::node_primary;
+
+primary_psql("
+	CREATE TABLE t1(id int) USING tde_heap;
+	INSERT INTO t1 SELECT generate_series(1,10000);
+");
+
+primary_psql("CHECKPOINT");
+
+primary_psql("SELECT pg_switch_wal();");
+primary_psql("CHECKPOINT");
+wait_for_archive($archive_dir, $node_primary);
+
+RewindTest::create_standby($cluster_name);
+
+my $node_standby = $RewindTest::node_standby;
+
+primary_psql("SELECT pg_switch_wal();");
+primary_psql("CHECKPOINT");
+wait_for_archive($archive_dir, $node_primary);
+
+RewindTest::promote_standby();
+
+
+standby_psql("INSERT INTO t1 VALUES (999999)");
+standby_psql("SELECT pg_switch_wal()");
+standby_psql("CHECKPOINT");
+wait_for_archive($archive_dir, $node_standby);
+
+
+my $newkey = "key_after_promotion";
+standby_psql(
+	"SELECT pg_tde_create_key_using_global_key_provider('$newkey', 'file-keyring-wal')"
+);
+standby_psql(
+	"SELECT pg_tde_set_key_using_global_key_provider('$newkey', 'file-keyring-wal')"
+);
+standby_psql("SELECT pg_switch_wal();");
+
+
+standby_psql("
+	CREATE TABLE target_only(id int) USING tde_heap;
+	INSERT INTO target_only VALUES (1),(2);
+");
+
+primary_psql("
+	CREATE TABLE source_only(id int) USING tde_heap;
+	INSERT INTO source_only VALUES (10),(20);
+");
+
+primary_psql("SELECT pg_switch_wal();");
+primary_psql("CHECKPOINT");
+wait_for_archive($archive_dir, $node_primary);
+
+standby_psql("SELECT pg_switch_wal();");
+standby_psql("CHECKPOINT");
+wait_for_archive($archive_dir, $node_standby);
+
+$node_primary->stop;
+
+my $primary_pgdata = $node_primary->data_dir;
+my $standby_pgdata = $node_standby->data_dir;
+
+copy(
+	"$primary_pgdata/postgresql.conf",
+	"$tempdir/primary-postgresql.conf.tmp");
+
+$node_standby->stop;
+command_ok(
+	[
+		'pg_tde_rewind',
+		"--debug",
+		"--source-pgdata=$standby_pgdata",
+		"--target-pgdata=$primary_pgdata",
+		"--restore-target-wal",
+		"--config-file",
+		"$tempdir/primary-postgresql.conf.tmp"
+	],
+	'pg_rewind local');
+
+move(
+	"$tempdir/primary-postgresql.conf.tmp",
+	"$primary_pgdata/postgresql.conf");
+
+
+$node_primary->start;
+
+
+ok(!$RewindTest::node_primary->log_contains('invalid magic number'),
+	'verify there are no "invalid magic number"');
+
+RewindTest::clean_rewind_test();
+
+
+done_testing();


### PR DESCRIPTION
Before this change, all segments that were restored from the archive by extractPageMap flew under the radar as it run after the rewind built map files on the destination. Hence, all these segments are just neglected by the later actions. This change makes all restored data from the active segments to be re-encrypted later on.

Fix PG-2397
For PG-2407