### PR TITLE
Fix re-encryption of segmented relations

### DIFF
--- a/fetools/pg18/pg_rewind/libpq_source.c
+++ b/fetools/pg18/pg_rewind/libpq_source.c
@@ -618,13 +618,13 @@ process_queued_fetch_requests(libpq_source *src)
 			{
 				Assert(chunksize % BLCKSZ == 0);
 
-				ensure_tde_keys(filename);
+				ensure_tde_keys_for_rel(filename);
 
 				for (int i = 0; i < chunksize / BLCKSZ; i++)
 				{
 					unsigned char *data = (unsigned char *) chunk + BLCKSZ * i;
 
-					tde_reencrypt_block(data, chunkoff + BLCKSZ * i, MAIN_FORKNUM);
+					tde_reencrypt_block_in_current_file(data, chunkoff + BLCKSZ * i, MAIN_FORKNUM);
 				}
 			}
 			write_target_range(chunk, chunkoff, chunksize);

--- a/fetools/pg18/pg_rewind/libpq_source.c
+++ b/fetools/pg18/pg_rewind/libpq_source.c
@@ -442,7 +442,6 @@ static void
 libpq_finish_fetch(rewind_source *source)
 {
 	process_queued_fetch_requests((libpq_source *) source);
-	flush_current_tde_rel_key();
 }
 
 static void

--- a/fetools/pg18/pg_rewind/local_source.c
+++ b/fetools/pg18/pg_rewind/local_source.c
@@ -157,7 +157,7 @@ local_queue_fetch_range(rewind_source *source, const char *path, off_t off,
 
 	open_target_file(path, false);
 
-	ensure_tde_keys(path);
+	ensure_tde_keys_for_rel(path);
 
 	while (end - begin > 0)
 	{
@@ -177,7 +177,7 @@ local_queue_fetch_range(rewind_source *source, const char *path, off_t off,
 			pg_fatal("unexpected EOF while reading file \"%s\"", srcpath);
 
 		/* Re-encrypt blocks with a proper key if needed. */
-		tde_reencrypt_block((unsigned char *) buf.data, begin, MAIN_FORKNUM);
+		tde_reencrypt_block_in_current_file((unsigned char *) buf.data, begin, MAIN_FORKNUM);
 
 		write_target_range(buf.data, begin, readlen);
 		begin += readlen;

--- a/fetools/pg18/pg_rewind/local_source.c
+++ b/fetools/pg18/pg_rewind/local_source.c
@@ -206,8 +206,10 @@ local_fetch_tde_keys(rewind_source *source)
 static void
 local_finish_fetch(rewind_source *source)
 {
-	/* Ensure the recent key used to process data is on the disk  */
-	flush_current_tde_rel_key();
+	/*
+	 * Noop for the local source as it doesn't fetch files in batches. Hence
+	 * everything is processed by now.
+	 */
 }
 
 static void

--- a/fetools/pg18/pg_rewind/pg_rewind.c
+++ b/fetools/pg18/pg_rewind/pg_rewind.c
@@ -578,6 +578,8 @@ perform_rewind(filemap_t *filemap, rewind_source *source,
 	size_t		size;
 	char	   *buffer;
 
+	tde_flushkey_init();
+
 	/*
 	 * Execute the actions in the file map, fetching data from the source
 	 * system as needed.
@@ -668,6 +670,7 @@ perform_rewind(filemap_t *filemap, rewind_source *source,
 	/* ensure (re-encrypt) destination's segments recovered from the archive */
 	ensure_tde_archive_wal();
 
+	flush_rel_keys();
 	fetch_tde_dir();
 
 	progress_report(true);

--- a/fetools/pg18/pg_rewind/pg_rewind.c
+++ b/fetools/pg18/pg_rewind/pg_rewind.c
@@ -620,12 +620,12 @@ perform_rewind(filemap_t *filemap, rewind_source *source,
 				 * Partial rewrites will ensure the keys on their own.
 				 * Moreover, some partial updates, when the source is libpq,
 				 * may happen in the last turn, when source->finish_fetch() is
-				 * called. So running ensure_tde_keys for such files
+				 * called. So running ensure_tde_keys_for_rel for such files
 				 * prematurely will make them unreadable since the source key
 				 * would be updated before we use it to decrypt source data.
 				 */
 				if (entry->target_pages_to_overwrite.bitmapsize == 0)
-					ensure_tde_keys(entry->path);
+					ensure_tde_keys_for_rel(entry->path);
 				break;
 
 			case FILE_ACTION_ENSURE_WAL_SEG:
@@ -639,7 +639,7 @@ perform_rewind(filemap_t *filemap, rewind_source *source,
 			case FILE_ACTION_TRUNCATE:
 				truncate_target_file(entry->path, entry->source_size);
 				if (entry->target_pages_to_overwrite.bitmapsize == 0)
-					ensure_tde_keys(entry->path);
+					ensure_tde_keys_for_rel(entry->path);
 				break;
 
 			case FILE_ACTION_COPY_TAIL:

--- a/fetools/pg18/pg_rewind/tde_ops.c
+++ b/fetools/pg18/pg_rewind/tde_ops.c
@@ -16,6 +16,7 @@
 #include "access/pg_tde_xlog_keys.h"
 #include "access/pg_tde_xlog_smgr.h"
 #include "common/pg_tde_utils.h"
+#include "common/hashfn.h"
 #include "pg_tde.h"
 
 static void copy_dir(const char *src, const char *dst);
@@ -44,9 +45,111 @@ typedef struct
 
 static current_file_data current_tde_file = {0};
 
+typedef struct flushkey_entry
+{
+	RelFileLocator rloc;
+	InternalKey *target_key;
+
+	uint32		status;			/* used by hash table */
+} flushkey_entry;
+
+#define SH_PREFIX				flushkey
+#define SH_ELEMENT_TYPE			flushkey_entry
+#define SH_KEY_TYPE				RelFileLocator
+#define SH_KEY					rloc
+#define SH_HASH_KEY(tb, key)	hash_combine(hash_combine(hash_bytes_uint32((key).spcOid), \
+											 hash_bytes_uint32((key).dbOid)), \
+										 hash_bytes_uint32((key).relNumber))
+#define SH_EQUAL(tb, a, b)		RelFileLocatorEquals(a, b)
+#define SH_SCOPE				static inline
+#define SH_RAW_ALLOCATOR		pg_malloc0
+#define SH_DECLARE
+#define SH_DEFINE
+#include "lib/simplehash.h"
+
+#define FLUSHKEY_INIT_SIZE 1000
+
+static flushkey_hash *flushkey = NULL;
+
 /* Dir for an operational copy of source's tde files (_keys, etc)  */
 static char tde_tmp_source[MAXPGPATH] = "";
 static bool source_has_tde = false;
+
+static void reencrypt_fork(ForkNumber fork);
+
+/* Initialise hashtabe for re-encryption keys */
+void
+tde_flushkey_init(void)
+{
+	flushkey = flushkey_create(FLUSHKEY_INIT_SIZE, NULL);
+}
+
+/*
+ * Add a key that was used for relation re-encryption to the hash. We will
+ * write all such keys later to the source key files at the end of rewind.
+ */
+static void
+flushkey_add_entry(RelFileLocator rloc, InternalKey *key)
+{
+	flushkey_entry *entry;
+	bool		found;
+
+	Assert(key != NULL);
+	Assert(flushkey != NULL);
+
+	entry = flushkey_insert(flushkey, rloc, &found);
+
+	if (!found)
+	{
+		entry->rloc = rloc;
+		entry->target_key = key;
+
+		Assert(current_tde_file.source_key != NULL);
+
+		/* TODO: should this be moved to flush_rel_keys()? */
+		reencrypt_fork(FSM_FORKNUM);
+		reencrypt_fork(VISIBILITYMAP_FORKNUM);
+
+		/* free only the source key, as we need the target's one for later */
+		pfree(current_tde_file.source_key);
+		memset(&current_tde_file, 0, sizeof(current_tde_file));
+	}
+}
+
+/*
+ * Write all destination internal key that was used to re-encrypt relation data
+ * to the sorce (if there is any).
+ */
+void
+flush_rel_keys(void)
+{
+	flushkey_iterator iter;
+	flushkey_entry *entry;
+
+	if (flushkey == NULL)
+		return;
+
+	/* add keys for the last file, if there are any */
+	if (current_tde_file.source_key != NULL)
+		flushkey_add_entry(current_tde_file.rlocator, current_tde_file.target_key);
+
+	pg_tde_set_data_dir(tde_tmp_source);
+	flushkey_start_iterate(flushkey, &iter);
+
+	while ((entry = flushkey_iterate(flushkey, &iter)) != NULL)
+	{
+		RelPathStr	rp = relpathperm(entry->rloc, MAIN_FORKNUM);
+
+		Assert(entry->target_key != NULL);
+
+		pg_log_debug("update internal key for \"%s\"", rp.str);
+
+		if (!dry_run)
+			pg_tde_save_smgr_key(entry->rloc, entry->target_key, true);
+
+		pfree(entry->target_key);
+	}
+}
 
 static void
 reencrypt_fork(ForkNumber fork)
@@ -119,30 +222,6 @@ reencrypt_fork(ForkNumber fork)
 	}
 
 	close(fd);
-}
-
-/*
- * Write the recent internal key that was used to re-encrypt relation data (if
- * there is any).
- */
-void
-flush_current_tde_rel_key(void)
-{
-	if (current_tde_file.source_key == NULL)
-		return;
-
-	pg_log_debug("ensure forks encryption for \"%s\"", current_tde_file.path);
-
-	reencrypt_fork(FSM_FORKNUM);
-	reencrypt_fork(VISIBILITYMAP_FORKNUM);
-
-	pg_log_debug("update internal key for \"%s\"", current_tde_file.path);
-	pg_tde_set_data_dir(tde_tmp_source);
-	pg_tde_save_smgr_key(current_tde_file.rlocator, current_tde_file.target_key, true);
-
-	pfree(current_tde_file.source_key);
-	pfree(current_tde_file.target_key);
-	memset(&current_tde_file, 0, sizeof(current_tde_file));
 }
 
 void
@@ -245,14 +324,15 @@ ensure_tde_keys(const char *relpath)
 	if (!source_has_tde)
 		return;
 
-	/* the same file, nothing to do */
-	if (strcmp(current_tde_file.path, relpath) == 0)
-		return;
-
-	flush_current_tde_rel_key();
-
 	if (!path_rlocator(relpath, &rlocator, &segNo))
 		return;
+
+	/* the same relation, nothing to do */
+	if (RelFileLocatorEquals(rlocator, current_tde_file.rlocator))
+		return;
+
+	if (current_tde_file.source_key != NULL)
+		flushkey_add_entry(current_tde_file.rlocator, current_tde_file.target_key);
 
 	pg_tde_set_data_dir(tde_tmp_source);
 	current_tde_file.source_key = pg_tde_get_smgr_key(rlocator);

--- a/fetools/pg18/pg_rewind/tde_ops.c
+++ b/fetools/pg18/pg_rewind/tde_ops.c
@@ -49,6 +49,7 @@ typedef struct flushkey_entry
 {
 	RelFileLocator rloc;
 	InternalKey *target_key;
+	InternalKey *source_key;	/* needed for fork re-encryption */
 
 	uint32		status;			/* used by hash table */
 } flushkey_entry;
@@ -75,7 +76,8 @@ static flushkey_hash *flushkey = NULL;
 static char tde_tmp_source[MAXPGPATH] = "";
 static bool source_has_tde = false;
 
-static void reencrypt_fork(ForkNumber fork);
+static void reencrypt_rel(RelFileLocator rloc, ForkNumber fork, InternalKey *source_key, InternalKey *target_key);
+static void reencrypt_block(unsigned char *buf, off_t file_offset, ForkNumber fork, unsigned int segNo, InternalKey *source_key, InternalKey *target_key, const char *path);
 
 /* Initialise hashtabe for re-encryption keys */
 void
@@ -87,14 +89,15 @@ tde_flushkey_init(void)
 /*
  * Add a key that was used for relation re-encryption to the hash. We will
  * write all such keys later to the source key files at the end of rewind.
+ * It will make copy of the keys so they can/should be freed by the caller.
  */
 static void
-flushkey_add_entry(RelFileLocator rloc, InternalKey *key)
+flushkey_add_entry(RelFileLocator rloc, InternalKey *source_key, InternalKey *target_key)
 {
 	flushkey_entry *entry;
 	bool		found;
 
-	Assert(key != NULL);
+	Assert(source_key != NULL && target_key != NULL);
 	Assert(flushkey != NULL);
 
 	entry = flushkey_insert(flushkey, rloc, &found);
@@ -102,17 +105,20 @@ flushkey_add_entry(RelFileLocator rloc, InternalKey *key)
 	if (!found)
 	{
 		entry->rloc = rloc;
-		entry->target_key = key;
 
-		Assert(current_tde_file.source_key != NULL);
-
-		/* TODO: should this be moved to flush_rel_keys()? */
-		reencrypt_fork(FSM_FORKNUM);
-		reencrypt_fork(VISIBILITYMAP_FORKNUM);
-
-		/* free only the source key, as we need the target's one for later */
-		pfree(current_tde_file.source_key);
-		memset(&current_tde_file, 0, sizeof(current_tde_file));
+		/*
+		 * A copying here does the extra allocations, but simplifies the key's
+		 * freeing logic for the caller.
+		 */
+		entry->source_key = pg_malloc(sizeof(InternalKey));
+		entry->target_key = pg_malloc(sizeof(InternalKey));
+		*entry->target_key = *target_key;
+		*entry->source_key = *source_key;
+	}
+	else
+	{
+		Assert(memcmp(entry->source_key, source_key, sizeof(InternalKey)) == 0);
+		Assert(memcmp(entry->target_key, target_key, sizeof(InternalKey)) == 0);
 	}
 }
 
@@ -131,7 +137,7 @@ flush_rel_keys(void)
 
 	/* add keys for the last file, if there are any */
 	if (current_tde_file.source_key != NULL)
-		flushkey_add_entry(current_tde_file.rlocator, current_tde_file.target_key);
+		flushkey_add_entry(current_tde_file.rlocator, current_tde_file.source_key, current_tde_file.target_key);
 
 	pg_tde_set_data_dir(tde_tmp_source);
 	flushkey_start_iterate(flushkey, &iter);
@@ -145,83 +151,109 @@ flush_rel_keys(void)
 		pg_log_debug("update internal key for \"%s\"", rp.str);
 
 		if (!dry_run)
+		{
+			reencrypt_rel(entry->rloc, FSM_FORKNUM, entry->source_key, entry->target_key);
+			reencrypt_rel(entry->rloc, VISIBILITYMAP_FORKNUM, entry->source_key, entry->target_key);
 			pg_tde_save_smgr_key(entry->rloc, entry->target_key, true);
+		}
 
-		pfree(entry->target_key);
+		pg_free(entry->source_key);
+		pg_free(entry->target_key);
 	}
+
+	flushkey_destroy(flushkey);
+	flushkey = NULL;
+
+	if (current_tde_file.source_key != NULL)
+		pg_free(current_tde_file.source_key);
+
+	if (current_tde_file.target_key != NULL)
+		pg_free(current_tde_file.target_key);
 }
 
+/*
+ * Re-encrypt whole relation including segment files. Currently used to
+ * re-encrypt VM/FSM forks of relations that rewrote key.
+ */
 static void
-reencrypt_fork(ForkNumber fork)
+reencrypt_rel(RelFileLocator rloc, ForkNumber fork, InternalKey *source_key, InternalKey *target_key)
 {
 	int			fd;
 	char		srcpath[MAXPGPATH];
 	PGIOAlignedBlock buf;
-	off_t		offset;
-	RelPathStr	rp = relpathperm(current_tde_file.rlocator, fork);
-	static const char *const warning_hint = "Skipping the file, as the server can start and rebuild the broken VM/FSM file.";
+	size_t		offset;
+	RelPathStr	rp = relpathperm(rloc, fork);
+	const char *warning_hint = _("Skipping the file, as the server can start and rebuild the broken VM/FSM file.");
 
 	if (dry_run)
 		return;
 
-	snprintf(srcpath, sizeof(srcpath), "%s/%s", datadir_target, rp.str);
-
-	/* check if fork exists, nothing to do if it does not */
-	if (access(srcpath, F_OK) != 0)
-		return;
-
-	fd = open(srcpath, O_RDWR | PG_BINARY, 0);
-	if (fd < 0)
+	for (unsigned int segno = 0;; segno++)
 	{
-		/*
-		 * Server can recover from wrecked VM/FSM, hence only warnings here
-		 * and in the rest of the function
-		 */
-		pg_log_warning("could not open fork file \"%s\": %m", srcpath);
-		pg_log_warning_hint("%s", warning_hint);
-		return;
-	}
+		if (segno == 0)
+			snprintf(srcpath, sizeof(srcpath), "%s/%s", datadir_target, rp.str);
+		else
+			snprintf(srcpath, sizeof(srcpath), "%s/%s.%u", datadir_target, rp.str, segno);
 
-	offset = 0;
-	for (;;)
-	{
-		ssize_t		read_len;
+		/* file does not exist, nothing to do */
+		if (access(srcpath, F_OK) != 0)
+			return;
 
-		read_len = pg_pread(fd, buf.data, sizeof(buf.data), offset);
-
-		if ((read_len <= 0))
+		fd = open(srcpath, O_RDWR | PG_BINARY, 0);
+		if (fd < 0)
 		{
-			if (read_len < 0)
+			/*
+			 * Server can recover from wrecked VM/FSM, hence only warnings
+			 * here and in the rest of the function.
+			 */
+			pg_log_warning("could not open fork file for reading \"%s\": %m", srcpath);
+			pg_log_warning_hint("%s", warning_hint);
+			return;
+		}
+
+		pg_log_debug("re-encrypt fork file %s", srcpath);
+
+		offset = 0;
+		for (;;)
+		{
+			ssize_t		read_len;
+
+			read_len = pg_pread(fd, buf.data, sizeof(buf.data), offset);
+
+			if ((read_len <= 0))
 			{
-				pg_log_warning("could not read block from fork file \"%s\": %m", srcpath);
-				pg_log_warning_hint("%s", warning_hint);
+				if (read_len < 0)
+				{
+					pg_log_warning("could not read block from fork file \"%s\": %m", srcpath);
+					pg_log_warning_hint("%s", warning_hint);
+				}
+
+				break;			/* EOF reached if read_len == 0 */
 			}
 
-			break;				/* EOF reached if read_len == 0 */
+			if (read_len != BLCKSZ)
+			{
+				pg_log_warning("unexpected read from fork file \"%s\"", srcpath);
+				pg_log_warning_detail("Expected %d bytes, but got %lu", BLCKSZ, read_len);
+				pg_log_warning_hint("%s", warning_hint);
+
+				break;
+			}
+
+			reencrypt_block((unsigned char *) buf.data, offset, fork, segno, source_key, target_key, srcpath);
+
+			if (pg_pwrite(fd, buf.data, read_len, offset) != read_len)
+			{
+				pg_log_warning("could not write block to fork file \"%s\": %m", srcpath);
+				pg_log_warning_hint("%s", warning_hint);
+
+				break;
+			}
+			offset += read_len;
 		}
 
-		if (read_len != BLCKSZ)
-		{
-			pg_log_warning("unexpected read from fork file \"%s\"", srcpath);
-			pg_log_warning_detail("Expected %d bytes, but got %lu", BLCKSZ, read_len);
-			pg_log_warning_hint("%s", warning_hint);
-
-			break;
-		}
-
-		tde_reencrypt_block((unsigned char *) buf.data, offset, fork);
-
-		if (pg_pwrite(fd, buf.data, read_len, offset) != read_len)
-		{
-			pg_log_warning("could not write block to fork file \"%s\": %m", srcpath);
-			pg_log_warning_hint("%s", warning_hint);
-
-			break;
-		}
-		offset += read_len;
+		close(fd);
 	}
-
-	close(fd);
 }
 
 void
@@ -313,8 +345,13 @@ ensure_tde_wal_seg(const char *relpath)
 	close(fd);
 }
 
+/*
+ * Checks if a given file has to be re-encrypted (relation has keys). And
+ * [re]sets rel keys in the internal state so they will be used in following
+ * calls of tde_reencrypt_block_in_current_file()
+ */
 void
-ensure_tde_keys(const char *relpath)
+ensure_tde_keys_for_rel(const char *relpath)
 {
 	char		target_tde_path[MAXPGPATH];
 	RelFileLocator rlocator;
@@ -331,8 +368,17 @@ ensure_tde_keys(const char *relpath)
 	if (RelFileLocatorEquals(rlocator, current_tde_file.rlocator))
 		return;
 
+	/*
+	 * This is a new relation. Save keys for later processing.
+	 */
 	if (current_tde_file.source_key != NULL)
-		flushkey_add_entry(current_tde_file.rlocator, current_tde_file.target_key);
+	{
+		flushkey_add_entry(current_tde_file.rlocator, current_tde_file.source_key, current_tde_file.target_key);
+
+		pg_free(current_tde_file.source_key);
+		pg_free(current_tde_file.target_key);
+		memset(&current_tde_file, 0, sizeof(current_tde_file));
+	}
 
 	pg_tde_set_data_dir(tde_tmp_source);
 	current_tde_file.source_key = pg_tde_get_smgr_key(rlocator);
@@ -359,22 +405,33 @@ ensure_tde_keys(const char *relpath)
 	}
 }
 
-void
-tde_reencrypt_block(unsigned char *buf, off_t file_offset, ForkNumber fork)
+static void
+reencrypt_block(unsigned char *buf, off_t file_offset, ForkNumber fork, unsigned int segNo, InternalKey *source_key, InternalKey *target_key, const char *path)
 {
 	BlockNumber blkno;
 
+	Assert(file_offset % BLCKSZ == 0);
+
+	blkno = file_offset / BLCKSZ + segNo * RELSEG_SIZE;
+
+	pg_log_debug("re-encrypt block in %s, offset: %ld, blockNum: %u", path, (long) file_offset, blkno);
+
+	tde_decrypt_smgr_block(source_key, fork, blkno, buf, buf);
+	tde_encrypt_smgr_block(target_key, fork, blkno, buf, buf);
+}
+
+/*
+ * Re-encrypt a BLCKSZ block at the given offset in the relation set by
+ * ensure_tde_keys_for_rel(). Noop if the relation is not encrypted.
+ */
+void
+tde_reencrypt_block_in_current_file(unsigned char *buf, off_t file_offset, ForkNumber fork)
+{
 	/* not a tde file, nothing do to */
 	if (current_tde_file.source_key == NULL)
 		return;
 
-	Assert(file_offset % BLCKSZ == 0);
-
-	blkno = file_offset / BLCKSZ + current_tde_file.segNo * RELSEG_SIZE;
-
-	pg_log_debug("re-encrypt block in %s, offset: %ld, blockNum: %u", current_tde_file.path, (long) file_offset, blkno);
-	tde_decrypt_smgr_block(current_tde_file.source_key, fork, blkno, buf, buf);
-	tde_encrypt_smgr_block(current_tde_file.target_key, fork, blkno, buf, buf);
+	reencrypt_block(buf, file_offset, fork, current_tde_file.segNo, current_tde_file.source_key, current_tde_file.target_key, current_tde_file.path);
 }
 
 static void

--- a/fetools/pg18/pg_rewind/tde_ops.h
+++ b/fetools/pg18/pg_rewind/tde_ops.h
@@ -3,7 +3,6 @@
 
 #include "common/relpath.h"
 
-extern void flush_current_tde_rel_key(void);
 extern void ensure_tde_wal_seg(const char *relpath);
 extern void ensure_tde_keys(const char *relpath);
 extern void tde_reencrypt_block(unsigned char *buf, off_t file_offset, ForkNumber fork);
@@ -13,5 +12,7 @@ extern void write_tmp_source_file(const char *fname, char *buf, size_t size);
 extern void fetch_tde_dir(void);
 extern void copy_tmp_tde_files(const char *from);
 extern void init_tde(void);
+extern void flush_rel_keys(void);
+extern void tde_flushkey_init(void);
 
 #endif							/* PG_REWIND_TDE_FILE_H */

--- a/fetools/pg18/pg_rewind/tde_ops.h
+++ b/fetools/pg18/pg_rewind/tde_ops.h
@@ -4,8 +4,8 @@
 #include "common/relpath.h"
 
 extern void ensure_tde_wal_seg(const char *relpath);
-extern void ensure_tde_keys(const char *relpath);
-extern void tde_reencrypt_block(unsigned char *buf, off_t file_offset, ForkNumber fork);
+extern void ensure_tde_keys_for_rel(const char *relpath);
+extern void tde_reencrypt_block_in_current_file(unsigned char *buf, off_t file_offset, ForkNumber fork);
 
 extern void destroy_tde_tmp_dir(void);
 extern void write_tmp_source_file(const char *fname, char *buf, size_t size);

--- a/meson.build
+++ b/meson.build
@@ -305,6 +305,7 @@ tap_tests = [
   't/pg_rewind_enc_fsm.pl',
   't/pg_rewind_enc_keep_archive_wal.pl',
   't/pg_rewind_enc_keep_wal_seg.pl',
+  't/pg_rewind_enc_rel_segment.pl',
   't/pg_rewind_enc_unchanged_rel.pl',
   't/pg_rewind_extrafiles.pl',
   't/pg_rewind_growing_files.pl',

--- a/t/pg_rewind_enc_rel_segment.pl
+++ b/t/pg_rewind_enc_rel_segment.pl
@@ -1,0 +1,52 @@
+# Triggers a blocks re-encryption of the segmented relation to test fix for
+# PG-2407 case 1
+#
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+use FindBin;
+use lib $FindBin::RealBin;
+
+use RewindTest;
+
+my $test_mode = 'local';
+
+RewindTest::setup_cluster($test_mode, [],
+	[ 'wal_keep_size=4GB', 'max_wal_size=4GB' ]);
+RewindTest::start_primary();
+
+RewindTest::create_standby($test_mode);
+
+# Create a segmented relation (size > 1Gb)
+primary_psql("
+	CREATE TABLE t1 (id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, f1 TEXT) USING tde_heap;
+	INSERT INTO t1 (f1) SELECT repeat(md5(g::text), 60) FROM generate_series(1, 600_000) g;
+");
+primary_psql("CHECKPOINT");
+
+# Crosscheck that the relation is segmented
+my $fpath =
+  $node_primary->safe_psql('postgres', "SELECT pg_relation_filepath('t1')");
+ok(-e $node_primary->data_dir . "/$fpath.1",
+	'segmented relation file exists');
+
+RewindTest::promote_standby();
+
+# # Makes pg_rewind to copy some blocks of the relation
+# # from both segments
+primary_psql("UPDATE t1 SET f1='YYYYYYY' WHERE id % 1000 = 0;");
+
+RewindTest::run_pg_rewind($test_mode);
+
+check_query(
+	'SELECT count(*) FROM t1',
+	qq(600000
+),
+	'tail-copy');
+
+RewindTest::clean_rewind_test();
+
+
+done_testing();


### PR DESCRIPTION
If the relation is segmented, there is no guarantee that the pg_rewind
processes all segments in the sequence. So the approach of dumping the
relation key into the source when we switch to the next file, or even
with rlocator, won't work. It is common to have the next sequence of
file processing:
base/16384/16443
base/16384/16440
base/16384/16443.1
So by the time we get to the 16443.1 segment, the keys for 16443 are
rewritten, and it can't properly decrypt it.

To fix this, instead of writing keys on the file switch, we add them
to the hashmap and process them in the end, after all the files.

It also fixes segmented forks (VM/FSM).
A TAP test for segmented forks would be problematic as it'd require a relation of ~3.5Tb size

For PG-2407