### PR TITLE
PG-2439 Build with all LDFLAGS from PostgreSQL to fix RPATH builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ project('pg_tde',
 fs = import('fs')
 
 pg_config = find_program(get_option('pg_config'))
+shsplit = find_program(files('shsplit'))
 
 bindir = run_command(pg_config, '--bindir', check: true).stdout().strip()
 includedir = run_command(pg_config, '--includedir', check: true).stdout().strip()
@@ -15,7 +16,27 @@ libdir = run_command(pg_config, '--libdir', check: true).stdout().strip()
 pkgincludedir = run_command(pg_config, '--pkgincludedir', check: true).stdout().strip()
 pkglibdir = run_command(pg_config, '--pkglibdir', check: true).stdout().strip()
 sharedir = run_command(pg_config, '--sharedir', check: true).stdout().strip()
+ldflags = run_command(shsplit, pg_config.full_path(), '--ldflags', check: true).stdout()
+ldflags_ex = run_command(shsplit, pg_config.full_path(), '--ldflags_ex', check: true).stdout()
+ldflags_sl = run_command(shsplit, pg_config.full_path(), '--ldflags_sl', check: true).stdout()
 version = run_command(pg_config, '--version', check: true).stdout().strip()
+
+# Handle empty string until we can use splitlines in Meson 1.2.0
+if ldflags == ''
+  ldflags = []
+else
+  ldflags = ldflags.strip().split('\n')
+endif
+if ldflags_ex == ''
+  ldflags_ex = []
+else
+  ldflags_ex = ldflags_ex.strip().split('\n')
+endif
+if ldflags_sl == ''
+  ldflags_sl = []
+else
+  ldflags_sl = ldflags_sl.strip().split('\n')
+endif
 
 cc = meson.get_compiler('c')
 
@@ -55,7 +76,8 @@ incdirs = include_directories(
   pkgincludedir / 'internal',
 )
 
-backend_link_args = []
+backend_link_args = ldflags + ldflags_sl
+frontend_link_args = ldflags + ldflags_ex
 
 if host_machine.system() == 'darwin'
   backend_link_args += ['-bundle_loader', bindir / 'postgres']
@@ -153,6 +175,7 @@ executable('pg_tde_change_key_provider',
   install: true,
   install_dir: bindir,
   link_with: [pg_tde_frontend],
+  link_args: frontend_link_args,
 )
 
 executable('pg_tde_archive_decrypt',
@@ -161,6 +184,7 @@ executable('pg_tde_archive_decrypt',
   install: true,
   install_dir: bindir,
   link_with: [pg_tde_frontend, pg_tde_frontend_xlog],
+  link_args: frontend_link_args,
 )
 
 executable('pg_tde_restore_encrypt',
@@ -169,6 +193,7 @@ executable('pg_tde_restore_encrypt',
   install: true,
   install_dir: bindir,
   link_with: [pg_tde_frontend, pg_tde_frontend_xlog],
+  link_args: frontend_link_args,
 )
 
 executable('pg_tde_upgrade',
@@ -177,6 +202,7 @@ executable('pg_tde_upgrade',
   install: true,
   install_dir: bindir,
   dependencies: [pgcommon, pgport],
+  link_args: frontend_link_args,
 )
 
 if major_version == 18
@@ -209,6 +235,7 @@ executable('pg_tde_basebackup',
   install_dir: bindir,
   dependencies: [pq, z],
   link_with: [pg_tde_frontend, pg_tde_frontend_xlog],
+  link_args: frontend_link_args,
 )
 
 executable('pg_tde_checksums',
@@ -219,6 +246,7 @@ executable('pg_tde_checksums',
   install: true,
   install_dir: bindir,
   link_with: [pg_tde_frontend],
+  link_args: frontend_link_args,
 )
 
 executable('pg_tde_resetwal',
@@ -229,6 +257,7 @@ executable('pg_tde_resetwal',
   install: true,
   install_dir: bindir,
   link_with: [pg_tde_frontend, pg_tde_frontend_xlog],
+  link_args: frontend_link_args,
 )
 
 executable('pg_tde_rewind',
@@ -247,6 +276,7 @@ executable('pg_tde_rewind',
   install_dir: bindir,
   dependencies: [pq],
   link_with: [pg_tde_frontend, pg_tde_frontend_xlog],
+  link_args: frontend_link_args,
 )
 
 executable('pg_tde_waldump',
@@ -283,6 +313,7 @@ executable('pg_tde_waldump',
   install_dir: bindir,
   c_args: ['-DFRONTEND'],
   link_with: [pg_tde_frontend, pg_tde_frontend_xlog],
+  link_args: frontend_link_args,
 )
 
 tap_tests = [

--- a/shsplit
+++ b/shsplit
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import shlex
+import subprocess
+import sys
+
+sp = subprocess.run(sys.argv[1:], stdout=subprocess.PIPE, text=True)
+if sp.returncode != 0:
+	sys.exit(sp.returncode)
+
+for s in shlex.split(sp.stdout):
+	print(s)


### PR DESCRIPTION
When PostgreSQL was built with RPATH that was not honored when we built `pg_tde` which could mean that the backend may load one version of `libpq` while our `pg_tde_*` frontend tools could load another and that can cause issues at least with the `--write-recovery-conf` argument to pg_rewind when `GenerateRecoveryConfig()` calls into `libpq` and gets options not supported by the version of `libpq` used by the backend.

To fix this we just blindly pass along ass `LDFLAGS` invluding (`LDFLAGS_EX` and `LDFLAGS_SL`) which should include all the options necessary for an RPATH build. This should also be good in general since the linker flags could potentially contain other important options.

The Meson code for this sadly ends up quite ugly due to PostgreSQL not supporting `pkgconfig` for extensions and us depending on a Meson version which does not support `splitlines()` yet.