### PR TITLE
Output pg_config in the CI before building pg_tde

### DIFF
--- a/ci_scripts/build.sh
+++ b/ci_scripts/build.sh
@@ -38,6 +38,9 @@ case "$1" in
         ;;
 esac
 
+echo "# pg_config"
+"$PG_CONFIG"
+
 cd "$SCRIPT_DIR/.."
 meson setup --buildtype="$BUILD_TYPE" -Dpg_config="$PG_CONFIG" -Dwerror=true $ARGS ../build
 meson install -C ../build


### PR DESCRIPTION
When debugging the RPATH issues this was a regular thing I needed to do and it was too when I was working with other bugs in our Meson build so make this debug output permanent in our CI scripts.