### PR TITLE
TMP remove pg17 tests for fix_pg_rewind branch

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg_version: [17, 18]
+        pg_version: [18]
         os: [ubuntu-24.04]
         compiler: [gcc, clang]
         build_type: [debugoptimized]
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg_version: [17, 18]
+        pg_version: [18]
         os: [ubuntu-24.04-arm]
         compiler: [gcc, clang]
         build_type: [debugoptimized]


### PR DESCRIPTION
It has changes only for pg18 so far. Hence, pg17 tests skew CI output in PRs