### PR TITLE
pg_tde_rewind code quality improvements

### DIFF
--- a/fetools/pg18/pg_rewind/local_source.c
+++ b/fetools/pg18/pg_rewind/local_source.c
@@ -187,23 +187,16 @@ local_queue_fetch_range(rewind_source *source, const char *path, off_t off,
 		pg_fatal("could not close file \"%s\": %m", srcpath);
 }
 
-static bool
-directory_exists(const char *dir)
-{
-	struct stat st;
-
-	return stat(dir, &st) == 0 && S_ISDIR(st.st_mode);
-}
-
 static void
 local_fetch_tde_keys(rewind_source *source)
 {
 	char		tde_source_dir[MAXPGPATH];
+	struct stat st;
 	const char *datadir = ((local_source *) source)->datadir;
 
 	snprintf(tde_source_dir, sizeof(tde_source_dir), "%s/%s", datadir, PG_TDE_DATA_DIR);
 
-	if (!directory_exists(tde_source_dir))
+	if (stat(tde_source_dir, &st) != 0 || !S_ISDIR(st.st_mode))
 		return;
 
 	init_tde();

--- a/fetools/pg18/pg_rewind/tde_ops.c
+++ b/fetools/pg18/pg_rewind/tde_ops.c
@@ -277,7 +277,7 @@ write_file(const char *path, char *buf, size_t size)
 {
 	int			fd;
 
-	fd = open(path, O_WRONLY | O_CREAT | PG_BINARY, pg_file_create_mode);
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY, pg_file_create_mode);
 	if (fd < 0)
 		pg_fatal("could not create temporary tde file \"%s\": %m", path);
 

--- a/fetools/pg18/pg_rewind/tde_ops.c
+++ b/fetools/pg18/pg_rewind/tde_ops.c
@@ -38,11 +38,10 @@ static bool source_has_tde = false;
 static void
 reencrypt_fork(ForkNumber fork)
 {
-	int			srcfd;
-	int			trgfd;
+	int			fd;
 	char		srcpath[MAXPGPATH];
 	PGIOAlignedBlock buf;
-	size_t		written_len;
+	off_t		offset;
 	RelPathStr	rp = relpathperm(current_tde_file.rlocator, fork);
 	static const char *const warning_hint = "Skipping the file, as the server can start and rebuild the broken VM/FSM file.";
 
@@ -55,33 +54,24 @@ reencrypt_fork(ForkNumber fork)
 	if (access(srcpath, F_OK) != 0)
 		return;
 
-	srcfd = open(srcpath, O_RDONLY | PG_BINARY, 0);
-	if (srcfd < 0)
+	fd = open(srcpath, O_RDWR | PG_BINARY, 0);
+	if (fd < 0)
 	{
 		/*
 		 * Server can recover from wrecked VM/FSM, hence only warnings here
 		 * and in the rest of the function
 		 */
-		pg_log_warning("could not open fork file for reading \"%s\": %m", srcpath);
+		pg_log_warning("could not open fork file \"%s\": %m", srcpath);
 		pg_log_warning_hint("%s", warning_hint);
 		return;
 	}
 
-	trgfd = open(srcpath, O_WRONLY | PG_BINARY, 0);
-	if (trgfd < 0)
-	{
-		pg_log_warning("could not open fork file for writing \"%s\": %m", srcpath);
-		pg_log_warning_hint("%s", warning_hint);
-		close(srcfd);
-		return;
-	}
-
-	written_len = 0;
+	offset = 0;
 	for (;;)
 	{
 		ssize_t		read_len;
 
-		read_len = read(srcfd, buf.data, sizeof(buf.data));
+		read_len = pg_pread(fd, buf.data, sizeof(buf.data), offset);
 
 		if ((read_len <= 0))
 		{
@@ -103,20 +93,19 @@ reencrypt_fork(ForkNumber fork)
 			break;
 		}
 
-		tde_reencrypt_block((unsigned char *) buf.data, written_len, fork);
+		tde_reencrypt_block((unsigned char *) buf.data, offset, fork);
 
-		if (write(trgfd, buf.data, read_len) != read_len)
+		if (pg_pwrite(fd, buf.data, read_len, offset) != read_len)
 		{
 			pg_log_warning("could not write block to fork file \"%s\": %m", srcpath);
 			pg_log_warning_hint("%s", warning_hint);
 
 			break;
 		}
-		written_len += read_len;
+		offset += read_len;
 	}
 
-	close(srcfd);
-	close(trgfd);
+	close(fd);
 }
 
 /*
@@ -312,25 +301,25 @@ write_tmp_source_file(const char *fname, char *buf, size_t size)
 static void
 copy_dir(const char *src, const char *dst)
 {
-	DIR		   *xldir;
-	struct dirent *xlde;
+	DIR		   *dir;
+	struct dirent *de;
 	char		src_path[MAXPGPATH];
 	char		dst_path[MAXPGPATH];
 
-	xldir = opendir(src);
-	if (xldir == NULL)
+	dir = opendir(src);
+	if (dir == NULL)
 		pg_fatal("could not open directory \"%s\": %m", src);
 
-	while (errno = 0, (xlde = readdir(xldir)) != NULL)
+	while (errno = 0, (de = readdir(dir)) != NULL)
 	{
 		struct stat fst;
 
-		if (strcmp(xlde->d_name, ".") == 0 ||
-			strcmp(xlde->d_name, "..") == 0)
+		if (strcmp(de->d_name, ".") == 0 ||
+			strcmp(de->d_name, "..") == 0)
 			continue;
 
-		snprintf(src_path, sizeof(src_path), "%s/%s", src, xlde->d_name);
-		snprintf(dst_path, sizeof(dst_path), "%s/%s", dst, xlde->d_name);
+		snprintf(src_path, sizeof(src_path), "%s/%s", src, de->d_name);
+		snprintf(dst_path, sizeof(dst_path), "%s/%s", dst, de->d_name);
 
 		if (lstat(src_path, &fst) < 0)
 			pg_fatal("could not stat file \"%s\": %m", src_path);
@@ -340,7 +329,7 @@ copy_dir(const char *src, const char *dst)
 			char	   *buf;
 			size_t		size;
 
-			buf = slurpFile(src, xlde->d_name, &size);
+			buf = slurpFile(src, de->d_name, &size);
 
 			write_file(dst_path, buf, size);
 			pg_free(buf);
@@ -350,7 +339,7 @@ copy_dir(const char *src, const char *dst)
 	if (errno)
 		pg_fatal("could not read directory \"%s\": %m", src);
 
-	if (closedir(xldir))
+	if (closedir(dir))
 		pg_fatal("could not close directory \"%s\": %m", src);
 }
 

--- a/src/bin/pg_tde_archive_decrypt.c
+++ b/src/bin/pg_tde_archive_decrypt.c
@@ -8,6 +8,7 @@
 #include "access/pg_tde_fe_init.h"
 #include "access/pg_tde_xlog_smgr.h"
 #include "pg_tde.h"
+#include "pg_tde_fe_archive_common.h"
 
 #include <signal.h>
 
@@ -227,23 +228,10 @@ main(int argc, char *argv[])
 											   "ARCHIVE-COMMAND", "fp",
 											   targetname, tmppath);
 
-		/*
-		 * Init WAL keys. We expect pg_tde (if any) one level up from the
-		 * destination file dir. Hence we expect destination files in the
-		 * <pgdata>/pg_wal dir and keys in <pgdata>/pg_tde. No `sep`, means no
-		 * dir in `sourcepath`, hence our workdir is `pg_wal` itself,
-		 * therefore look at ../pg_tde.
-		 */
 		{
-			char		tdedir[MAXPGPATH] = "../" PG_TDE_DATA_DIR;
+			char		tdedir[MAXPGPATH];
 
-			if (sep != NULL)
-			{
-				char		sourcedir[MAXPGPATH];
-
-				strlcpy(sourcedir, sourcepath, sep - sourcepath + 1);
-				snprintf(tdedir, sizeof(tdedir), "%s/../" PG_TDE_DATA_DIR, sourcedir);
-			}
+			derive_tde_dir_from_segment_path(sourcepath, sep, tdedir, sizeof(tdedir));
 
 			pg_tde_fe_init(tdedir);
 			TDEXLogSmgrInit();

--- a/src/bin/pg_tde_fe_archive_common.h
+++ b/src/bin/pg_tde_fe_archive_common.h
@@ -1,0 +1,29 @@
+#ifndef PG_TDE_FE_ARCHIVE_COMMON_H
+#define PG_TDE_FE_ARCHIVE_COMMON_H
+
+#include "pg_tde.h"
+
+/*
+ * Init WAL keys. We expect pg_tde (if any) one level up from the destination
+ * file dir. Hence we expect destination files in the <pgdata>/pg_wal dir and
+ * keys in <pgdata>/pg_tde. No `sep` means no dir in `segpath`, hence our
+ * workdir is `pg_wal` itself, therefore look at ../pg_tde.
+ */
+static inline void
+derive_tde_dir_from_segment_path(const char *segpath, const char *sep,
+								 char *tdedir, size_t tdedir_sz)
+{
+	if (sep != NULL)
+	{
+		char		segdir[MAXPGPATH];
+
+		strlcpy(segdir, segpath, sep - segpath + 1);
+		snprintf(tdedir, tdedir_sz, "%s/../" PG_TDE_DATA_DIR, segdir);
+	}
+	else
+	{
+		strlcpy(tdedir, "../" PG_TDE_DATA_DIR, tdedir_sz);
+	}
+}
+
+#endif							/* PG_TDE_FE_ARCHIVE_COMMON_H */

--- a/src/bin/pg_tde_restore_encrypt.c
+++ b/src/bin/pg_tde_restore_encrypt.c
@@ -8,6 +8,7 @@
 #include "access/pg_tde_fe_init.h"
 #include "access/pg_tde_xlog_smgr.h"
 #include "pg_tde.h"
+#include "pg_tde_fe_archive_common.h"
 
 #include <signal.h>
 
@@ -247,22 +248,9 @@ main(int argc, char *argv[])
 
 	if (issegment)
 	{
-		/*
-		 * Init WAL keys. We expect pg_tde (if any) one level up from the
-		 * destination file dir. Hence we expect destination files in the
-		 * <pgdata>/pg_wal dir and keys in <pgdata>/pg_tde. No `sep` means no
-		 * dir in `targetpath`, hence our workdir is `pg_wal` itself,
-		 * therefore look at ../pg_tde.
-		 */
-		char		tdedir[MAXPGPATH] = "../" PG_TDE_DATA_DIR;
+		char		tdedir[MAXPGPATH];
 
-		if (sep != NULL)
-		{
-			char		targetdir[MAXPGPATH];
-
-			strlcpy(targetdir, targetpath, sep - targetpath + 1);
-			snprintf(tdedir, sizeof(tdedir), "%s/../" PG_TDE_DATA_DIR, targetdir);
-		}
+		derive_tde_dir_from_segment_path(targetpath, sep, tdedir, sizeof(tdedir));
 
 		pg_tde_fe_init(tdedir);
 		TDEXLogSmgrInit();

--- a/src/catalog/tde_principal_key.c
+++ b/src/catalog/tde_principal_key.c
@@ -958,7 +958,7 @@ pg_tde_get_key_info(PG_FUNCTION_ARGS, Oid dbOid)
 static TDEPrincipalKey *fe_server_principal_key_cache = NULL;
 
 void
-clean_fe_server_principal_key_cache()
+clean_fe_server_principal_key_cache(void)
 {
 	pfree(fe_server_principal_key_cache);
 	fe_server_principal_key_cache = NULL;

--- a/src/common/pg_tde_utils.c
+++ b/src/common/pg_tde_utils.c
@@ -56,10 +56,8 @@ pg_tde_set_data_dir(const char *dir)
 {
 	Assert(dir != NULL);
 
-	memset(tde_data_dir, 0, sizeof(tde_data_dir));
 	strlcpy(tde_data_dir, dir, sizeof(tde_data_dir));
 
-	memset(wal_key_file_path, 0, sizeof(wal_key_file_path));
 	snprintf(wal_key_file_path, MAXPGPATH, "%s/" PG_TDE_WAL_KEY_FILE_NAME, tde_data_dir);
 
 	/* New dir, new keys. Reset caches */

--- a/src/encryption/enc_tde.c
+++ b/src/encryption/enc_tde.c
@@ -13,6 +13,7 @@
 #define AES_BLOCK_SIZE 		        16
 #define NUM_AES_BLOCKS_IN_BATCH     200
 #define DATA_BYTES_PER_AES_BATCH    (NUM_AES_BLOCKS_IN_BATCH * AES_BLOCK_SIZE)
+#define TDE_BLOCK_IV_LEN            16
 
 #ifdef ENCRYPTION_DEBUG
 static void
@@ -150,7 +151,7 @@ pg_tde_stream_crypt(const char *iv_prefix,
 static void
 CalcBlockIv(ForkNumber forknum, BlockNumber bn, const unsigned char *base_iv, unsigned char *iv)
 {
-	memset(iv, 0, 16);
+	memset(iv, 0, TDE_BLOCK_IV_LEN);
 
 	/* The init fork is copied to the main fork so we must use the same IV */
 	iv[7] = forknum == INIT_FORKNUM ? MAIN_FORKNUM : forknum;
@@ -160,14 +161,14 @@ CalcBlockIv(ForkNumber forknum, BlockNumber bn, const unsigned char *base_iv, un
 	iv[14] = bn >> 8;
 	iv[15] = bn;
 
-	for (int i = 0; i < 16; i++)
+	for (int i = 0; i < TDE_BLOCK_IV_LEN; i++)
 		iv[i] ^= base_iv[i];
 }
 
 void
-tde_decrypt_smgr_block(InternalKey *relKey, ForkNumber forknum, BlockNumber blocknum, const unsigned char *in, unsigned char *out)
+tde_decrypt_smgr_block(InternalKey *rel_key, ForkNumber forknum, BlockNumber blocknum, const unsigned char *in, unsigned char *out)
 {
-	unsigned char iv[16];
+	unsigned char iv[TDE_BLOCK_IV_LEN];
 	bool		allZero = true;
 
 	/*
@@ -191,17 +192,17 @@ tde_decrypt_smgr_block(InternalKey *relKey, ForkNumber forknum, BlockNumber bloc
 	if (allZero)
 		return;
 
-	CalcBlockIv(forknum, blocknum, relKey->base_iv, iv);
+	CalcBlockIv(forknum, blocknum, rel_key->base_iv, iv);
 
-	AesDecrypt(relKey->key, relKey->key_len, iv, in, BLCKSZ, out);
+	AesDecrypt(rel_key->key, rel_key->key_len, iv, in, BLCKSZ, out);
 }
 
 void
-tde_encrypt_smgr_block(InternalKey *relKey, ForkNumber forknum, BlockNumber blocknum, const unsigned char *in, unsigned char *out)
+tde_encrypt_smgr_block(InternalKey *rel_key, ForkNumber forknum, BlockNumber blocknum, const unsigned char *in, unsigned char *out)
 {
-	unsigned char iv[16];
+	unsigned char iv[TDE_BLOCK_IV_LEN];
 
-	CalcBlockIv(forknum, blocknum, relKey->base_iv, iv);
+	CalcBlockIv(forknum, blocknum, rel_key->base_iv, iv);
 
-	AesEncrypt(relKey->key, relKey->key_len, iv, in, BLCKSZ, out);
+	AesEncrypt(rel_key->key, rel_key->key_len, iv, in, BLCKSZ, out);
 }

--- a/src/include/encryption/enc_tde.h
+++ b/src/include/encryption/enc_tde.h
@@ -41,10 +41,10 @@ extern void pg_tde_stream_crypt(const char *iv_prefix,
 								int key_len,
 								void **ctxPtr);
 
-extern void tde_decrypt_smgr_block(InternalKey *relKey, ForkNumber forknum,
+extern void tde_decrypt_smgr_block(InternalKey *rel_key, ForkNumber forknum,
 								   BlockNumber blocknum, const unsigned char *in,
 								   unsigned char *out);
-extern void tde_encrypt_smgr_block(InternalKey *relKey, ForkNumber forknum,
+extern void tde_encrypt_smgr_block(InternalKey *rel_key, ForkNumber forknum,
 								   BlockNumber blocknum, const unsigned char *in,
 								   unsigned char *out);
 #endif							/* ENC_TDE_H */


### PR DESCRIPTION
Pure refactors, no behaviour change.

  * pg_tde_set_data_dir: drop redundant memsets before strlcpy/snprintf
  * enc_tde: name the 16-byte IV constant TDE_BLOCK_IV_LEN
  * enc_tde: rename relKey -> rel_key in the new public block helpers
  * tde_ops copy_dir: simplify loop variable names
  * archive tools: extract shared tdedir derivation helper
  * tde_ops reencrypt_fork: use one O_RDWR fd + pread/pwrite
  * local_source: inline single-use directory_exists helper