### PR TITLE
pg_rewind: use prefix check instead of substring for pg_tde dir

### DIFF
--- a/fetools/pg18/pg_rewind/filemap.c
+++ b/fetools/pg18/pg_rewind/filemap.c
@@ -734,7 +734,7 @@ decide_file_action(file_entry_t *entry)
 	 * Skip pg_tde key data. This is handled separately by combining the
 	 * source and target keys when processing relation files.
 	 */
-	if (strstr(path, "pg_tde/") != NULL)
+	if (strncmp(path, "pg_tde/", 7) == 0)
 		return FILE_ACTION_NONE;
 
 	/*


### PR DESCRIPTION
strstr matches anywhere in the path, so a hypothetical "foo_pg_tde/x" or a regular file whose name happens to contain "pg_tde/" would be silently skipped. We only mean to skip the pg_tde data directory at the root of PGDATA, so use a strncmp prefix check.