### PR TITLE
pg_rewind: honor TMPDIR for temporary pg_tde working directory

### DIFF
--- a/fetools/pg18/pg_rewind/tde_ops.c
+++ b/fetools/pg18/pg_rewind/tde_ops.c
@@ -32,7 +32,7 @@ typedef struct
 static current_file_data current_tde_file = {0};
 
 /* Dir for an operational copy of source's tde files (_keys, etc)  */
-static char tde_tmp_source[MAXPGPATH] = "/tmp/pg_tde_rewindXXXXXX";
+static char tde_tmp_source[MAXPGPATH] = "";
 static bool source_has_tde = false;
 
 static void
@@ -271,6 +271,14 @@ tde_reencrypt_block(unsigned char *buf, off_t file_offset, ForkNumber fork)
 static void
 create_tde_tmp_dir(void)
 {
+	const char *tmpdir = getenv("TMPDIR");
+
+	if (tmpdir == NULL || tmpdir[0] == '\0')
+		tmpdir = "/tmp";
+
+	snprintf(tde_tmp_source, sizeof(tde_tmp_source),
+			 "%s/pg_tde_rewindXXXXXX", tmpdir);
+
 	if (mkdtemp(tde_tmp_source) == NULL)
 		pg_fatal("could not create temporary directory \"%s\": %m", tde_tmp_source);
 
@@ -280,6 +288,8 @@ create_tde_tmp_dir(void)
 void
 destroy_tde_tmp_dir(void)
 {
+	if (tde_tmp_source[0] == '\0')
+		return;
 	rmtree(tde_tmp_source, true);
 }
 


### PR DESCRIPTION
The previous code hardcoded /tmp as the parent of the throwaway TDE key directory created via mkdtemp(). On hosts where /tmp is on a size-limited tmpfs, read-only, or simply absent, pg_tde_rewind would fail with an opaque "could not create temporary directory" error. Mirror PostgreSQL's convention of honouring $TMPDIR with a /tmp fallback.

While here, guard destroy_tde_tmp_dir (registered via atexit) so that an early abort before init_tde does not pass an empty path to rmtree.