### PR TITLE
Clean up and standardize the beginnings of TAP files

### DIFF
--- a/t/basebackup_default_key.pl
+++ b/t/basebackup_default_key.pl
@@ -8,10 +8,10 @@
 
 use strict;
 use warnings;
-use Test::More;
 use PostgreSQL::Test::Cluster;
-use PostgreSQL::Test::Utils;
 use PostgreSQL::Test::RecursiveCopy;
+use PostgreSQL::Test::Utils;
+use Test::More;
 
 my $keydir = PostgreSQL::Test::Utils::tempdir;
 

--- a/t/basebackup_default_key.pl
+++ b/t/basebackup_default_key.pl
@@ -5,7 +5,7 @@
 # configured cluster would fail with "could not find server principal key".
 
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::RecursiveCopy;
 use PostgreSQL::Test::Utils;

--- a/t/basebackup_default_key.pl
+++ b/t/basebackup_default_key.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 # Tests that pg_tde_basebackup -E works after setting just a default
 # principal key, without first restarting the primary. Before the fix,
 # the server (WAL) principal key was only materialized lazily on the

--- a/t/basic.pl
+++ b/t/basic.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;

--- a/t/basic.pl
+++ b/t/basic.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use PostgreSQL::Test::Cluster;

--- a/t/change_key_provider.pl
+++ b/t/change_key_provider.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use File::Copy;

--- a/t/change_key_provider.pl
+++ b/t/change_key_provider.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use File::Copy;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;

--- a/t/crash_recovery.pl
+++ b/t/crash_recovery.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use pgtde;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;

--- a/t/crash_recovery.pl
+++ b/t/crash_recovery.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use pgtde;

--- a/t/crash_recovery.pl
+++ b/t/crash_recovery.pl
@@ -5,7 +5,6 @@ use warnings;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
-use lib 't';
 use pgtde;
 
 my $stdout;

--- a/t/crash_recovery.pl
+++ b/t/crash_recovery.pl
@@ -2,10 +2,10 @@
 
 use strict;
 use warnings;
+use pgtde;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
-use pgtde;
 
 my $stdout;
 

--- a/t/default_principal_key.pl
+++ b/t/default_principal_key.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;

--- a/t/key_rotate_tablespace.pl
+++ b/t/key_rotate_tablespace.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;

--- a/t/key_rotate_tablespace.pl
+++ b/t/key_rotate_tablespace.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use PostgreSQL::Test::Cluster;

--- a/t/key_validation.pl
+++ b/t/key_validation.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use Fcntl 'SEEK_CUR';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;

--- a/t/key_validation.pl
+++ b/t/key_validation.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use Fcntl 'SEEK_CUR';

--- a/t/keys_update.pl
+++ b/t/keys_update.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 # Test migration older format of pg_tde/*_keys files. It starts a cluster
 # from preexising PGDATA. This PGDATA is the result of:
 # - Created and run cluster with pg_tde 2.1.1 and encrypted WAL

--- a/t/keys_update.pl
+++ b/t/keys_update.pl
@@ -5,7 +5,7 @@
 # - Crashed server (kill -9)
 
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;

--- a/t/kmip.pl
+++ b/t/kmip.pl
@@ -3,7 +3,6 @@
 use strict;
 use warnings;
 use Test::More;
-use lib 't';
 use CosmianKms;
 use PostgreSQL::Test::Utils;
 use PostgreSQL::Test::Cluster;

--- a/t/kmip.pl
+++ b/t/kmip.pl
@@ -2,12 +2,12 @@
 
 use strict;
 use warnings;
-use Test::More;
 use CosmianKms;
-use PostgreSQL::Test::Utils;
-use PostgreSQL::Test::Cluster;
 use IO::Socket::INET;
 use POSIX qw(:sys_wait_h);
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
 
 my $cosmian_bin = CosmianKms::find_binary();
 unless ($cosmian_bin)

--- a/t/kmip.pl
+++ b/t/kmip.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use CosmianKms;

--- a/t/kmip.pl
+++ b/t/kmip.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use CosmianKms;
 use IO::Socket::INET;
 use POSIX qw(:sys_wait_h);

--- a/t/regress.pl
+++ b/t/regress.pl
@@ -1,6 +1,5 @@
 use strict;
 use warnings FATAL => 'all';
-
 use Carp;
 use IPC::Run;
 use JSON::XS;

--- a/t/replication.pl
+++ b/t/replication.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use pgtde;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;

--- a/t/replication.pl
+++ b/t/replication.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use pgtde;

--- a/t/replication.pl
+++ b/t/replication.pl
@@ -5,7 +5,6 @@ use warnings;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
-use lib 't';
 use pgtde;
 
 my $stdout;

--- a/t/replication.pl
+++ b/t/replication.pl
@@ -2,10 +2,10 @@
 
 use strict;
 use warnings;
+use pgtde;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
-use pgtde;
 
 my $stdout;
 

--- a/t/reuse_relfilenode_in_cache.pl
+++ b/t/reuse_relfilenode_in_cache.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;

--- a/t/reuse_relfilenode_in_cache.pl
+++ b/t/reuse_relfilenode_in_cache.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use PostgreSQL::Test::Cluster;

--- a/t/rotate_key.pl
+++ b/t/rotate_key.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;

--- a/t/rotate_key.pl
+++ b/t/rotate_key.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use PostgreSQL::Test::Cluster;

--- a/t/tde_heap.pl
+++ b/t/tde_heap.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;

--- a/t/tde_heap.pl
+++ b/t/tde_heap.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use PostgreSQL::Test::Cluster;

--- a/t/tde_heap_aes_256.pl
+++ b/t/tde_heap_aes_256.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;

--- a/t/tde_heap_aes_256.pl
+++ b/t/tde_heap_aes_256.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use PostgreSQL::Test::Cluster;

--- a/t/unlogged_tables.pl
+++ b/t/unlogged_tables.pl
@@ -2,10 +2,10 @@
 
 use strict;
 use warnings;
+use pgtde;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
-use pgtde;
 
 my $keydir = PostgreSQL::Test::Utils::tempdir;
 

--- a/t/unlogged_tables.pl
+++ b/t/unlogged_tables.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use pgtde;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;

--- a/t/unlogged_tables.pl
+++ b/t/unlogged_tables.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use pgtde;

--- a/t/unlogged_tables.pl
+++ b/t/unlogged_tables.pl
@@ -5,7 +5,6 @@ use warnings;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
-use lib 't';
 use pgtde;
 
 my $keydir = PostgreSQL::Test::Utils::tempdir;

--- a/t/wal_archiving.pl
+++ b/t/wal_archiving.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;

--- a/t/wal_archiving.pl
+++ b/t/wal_archiving.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use PostgreSQL::Test::Cluster;

--- a/t/wal_archiving.pl
+++ b/t/wal_archiving.pl
@@ -2,9 +2,9 @@
 
 use strict;
 use warnings;
-use Test::More;
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
+use Test::More;
 
 # Test CLI tools directly
 

--- a/t/wal_encrypt.pl
+++ b/t/wal_encrypt.pl
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;

--- a/t/wal_encrypt.pl
+++ b/t/wal_encrypt.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 use PostgreSQL::Test::Cluster;


### PR DESCRIPTION
The `use` directives of our TAP files were all over the place. Some fixes:

- Sort the `use` directives alphabetically
- Remove `use lib 't'`
- Remove shebangs
- Always use `use warnings FATAL => 'all'`