### PR TITLE
Fix shsplit Python 3.6 compatibility on RHEL/OL/Rocky 8

### DIFF
--- a/shsplit
+++ b/shsplit
@@ -4,7 +4,7 @@ import shlex
 import subprocess
 import sys
 
-sp = subprocess.run(sys.argv[1:], stdout=subprocess.PIPE, text=True)
+sp = subprocess.run(sys.argv[1:], stdout=subprocess.PIPE, universal_newlines=True)
 if sp.returncode != 0:
 	sys.exit(sp.returncode)
 


### PR DESCRIPTION
subprocess.run(text=True) was introduced in Python 3.7. RHEL/OL/Rocky 8 ships Python 3.6, causing the build to fail with:

  TypeError: __init__() got an unexpected keyword argument 'text'

universal_newlines=True is the identical backport-safe spelling available since Python 2.4. No behaviour change on Python 3.7+.