### PR TITLE
PG-2473: MSVC portability fixes

### DIFF
--- a/src/access/pg_tde_xlog_smgr.c
+++ b/src/access/pg_tde_xlog_smgr.c
@@ -603,11 +603,13 @@ TDEXLogCryptBuffer(const void *buf, void *out_buf, size_t count, off_t offset,
 	}
 }
 
+#ifdef __SIZEOF_INT128__
 union u128cast
 {
 	char		a[16];
 	unsigned	__int128 i;
 };
+#endif
 
 /*
  * Calculate the start IV for an XLog segmenet.
@@ -622,6 +624,7 @@ union u128cast
 static void
 CalcXLogPageIVPrefix(TimeLineID tli, XLogRecPtr lsn, const unsigned char *base_iv, char *iv_prefix)
 {
+#ifdef __SIZEOF_INT128__
 	union u128cast base;
 	union u128cast iv;
 	unsigned	__int128 offset;
@@ -645,5 +648,45 @@ CalcXLogPageIVPrefix(TimeLineID tli, XLogRecPtr lsn, const unsigned char *base_i
 		iv_prefix[i] = iv.a[i];
 #else
 		iv_prefix[i] = iv.a[15 - i];
+#endif
+#else
+	/*
+	 * Fallback for compilers without __int128 (MSVC): emulate the 128-bit add
+	 * with two uint64 halves plus carry, byte-identical to the path above.
+	 * Little-endian only; no big-endian platform lacks __int128.
+	 */
+#ifdef WORDS_BIGENDIAN
+#error "pg_tde: the __int128-free XLog IV fallback is little-endian only"
+#endif
+	unsigned char base[16];
+	unsigned char iv[16];
+	uint64		base_lo,
+				base_hi,
+				offset_lo,
+				offset_hi,
+				iv_lo,
+				iv_hi,
+				carry;
+
+	for (int i = 0; i < 16; i++)
+		base[i] = base_iv[15 - i];
+
+	memcpy(&base_lo, &base[0], 8);
+	memcpy(&base_hi, &base[8], 8);
+
+	base_lo &= ~((uint64) 1 << 32);
+
+	offset_lo = (uint64) lsn << 32;
+	offset_hi = ((uint64) lsn >> 32) | ((uint64) (tli & 0xFFFF) << 48);
+
+	iv_lo = base_lo + offset_lo;
+	carry = (iv_lo < base_lo) ? 1 : 0;
+	iv_hi = base_hi + offset_hi + carry;
+
+	memcpy(&iv[0], &iv_lo, 8);
+	memcpy(&iv[8], &iv_hi, 8);
+
+	for (int i = 0; i < 16; i++)
+		iv_prefix[i] = iv[15 - i];
 #endif
 }

--- a/src/bin/pg_tde_archive_decrypt.c
+++ b/src/bin/pg_tde_archive_decrypt.c
@@ -211,14 +211,10 @@ main(int argc, char *argv[])
 
 	if (issegment)
 	{
-		char	   *s;
-
 		if (mkdtemp(tmpdir) == NULL)
 			pg_fatal("could not create temporary directory \"%s\": %m", tmpdir);
 
-		s = stpcpy(tmppath, tmpdir);
-		s = stpcpy(s, "/");
-		stpcpy(s, sourcename);
+		snprintf(tmppath, sizeof(tmppath), "%s/%s", tmpdir, sourcename);
 
 		/* There is a mostly harmless race condition with creating the dir */
 		signal(SIGTERM, trapsig);

--- a/src/bin/pg_tde_change_key_provider.c
+++ b/src/bin/pg_tde_change_key_provider.c
@@ -2,7 +2,7 @@
 
 #include "common/controldata_utils.h"
 #include "common/logging.h"
-#include "pg_getopt.h"
+#include "getopt_long.h"
 
 #include "catalog/tde_global_space.h"
 #include "catalog/tde_keyring.h"

--- a/src/bin/pg_tde_restore_encrypt.c
+++ b/src/bin/pg_tde_restore_encrypt.c
@@ -206,14 +206,10 @@ main(int argc, char *argv[])
 
 	if (issegment)
 	{
-		char	   *s;
-
 		if (mkdtemp(tmpdir) == NULL)
 			pg_fatal("could not create temporary directory \"%s\": %m", tmpdir);
 
-		s = stpcpy(tmppath, tmpdir);
-		s = stpcpy(s, "/");
-		stpcpy(s, targetname);
+		snprintf(tmppath, sizeof(tmppath), "%s/%s", tmpdir, targetname);
 
 		/* There is a mostly harmless race condition with creating the dir */
 		signal(SIGTERM, trapsig);

--- a/src/bin/pg_tde_upgrade.c
+++ b/src/bin/pg_tde_upgrade.c
@@ -2,7 +2,11 @@
 
 #include <signal.h>
 #include <sys/stat.h>
+#ifndef WIN32
 #include <sys/wait.h>
+#else
+#include <process.h>
+#endif
 
 #include "common/file_utils.h"
 #include "common/logging.h"
@@ -195,7 +199,9 @@ main(int argc, char *argv[])
 	char	   *new_pgdata = NULL;
 	char	   *pg_upgrade_path;
 	char	  **pg_upgrade_argv;
+#ifndef WIN32
 	pid_t		child;
+#endif
 	int			exitstatus;
 
 	/* Copy argv before getopt_long() modifies it. */
@@ -273,6 +279,7 @@ main(int argc, char *argv[])
 	pg_upgrade_argv[argc + 1] = tmpdir;
 	pg_upgrade_argv[argc + 2] = NULL;
 
+#ifndef WIN32
 	child = fork();
 	if (child == 0)
 	{
@@ -294,4 +301,14 @@ main(int argc, char *argv[])
 	else if (WIFSIGNALED(exitstatus))
 		pg_fatal("pg_upgrade (PID %d) was terminated by signal %d: %s",
 				 child, WTERMSIG(exitstatus), pg_strsignal(WTERMSIG(exitstatus)));
+#else
+	signal(SIGTERM, trapsig);
+	signal(SIGINT, trapsig);
+	atexit(cleanup_tmpdir);
+
+	exitstatus = (int) _spawnv(_P_WAIT, pg_upgrade_path, pg_upgrade_argv);
+	if (exitstatus < 0)
+		pg_fatal("could not run pg_upgrade executable: %m");
+	exit(exitstatus);
+#endif
 }

--- a/src/bin/pg_tde_upgrade.c
+++ b/src/bin/pg_tde_upgrade.c
@@ -6,7 +6,7 @@
 
 #include "common/file_utils.h"
 #include "common/logging.h"
-#include "pg_getopt.h"
+#include "getopt_long.h"
 
 static char tmpdir[MAXPGPATH] = "/tmp/pg_tde_upgradeXXXXXX";
 

--- a/src/catalog/tde_keyring.c
+++ b/src/catalog/tde_keyring.c
@@ -780,7 +780,7 @@ scan_key_provider_file(ProviderScanType scanType, void *scanKey, Oid dbOid)
 
 		if (scanType == PROVIDER_SCAN_BY_NAME)
 		{
-			if (strcasecmp(provider.provider_name, (char *) scanKey) == 0)
+			if (pg_strcasecmp(provider.provider_name, (char *) scanKey) == 0)
 				match = true;
 		}
 		else if (scanType == PROVIDER_SCAN_BY_ID)

--- a/src/catalog/tde_principal_key.c
+++ b/src/catalog/tde_principal_key.c
@@ -4,7 +4,17 @@
 
 #include "postgres.h"
 
+#ifdef WIN32
+#include <windows.h>
+/*
+ * Windows has no mlock(); VirtualLock pins pages in the process working
+ * set, which matches the intent (keep the principal key out of the swap
+ * file). VirtualLock returns nonzero on success, so translate to 0/-1.
+ */
+#define mlock(addr, len) (VirtualLock((addr), (len)) ? 0 : -1)
+#else
 #include <sys/mman.h>
+#endif
 #include <sys/time.h>
 
 #include "access/xlog.h"

--- a/src/include/pg_tde_fe.h
+++ b/src/include/pg_tde_fe.h
@@ -7,36 +7,86 @@
 
 #ifdef FRONTEND
 
+#include <stdarg.h>
+
 #include "postgres_fe.h"
 #include "common/logging.h"
 #include "common/file_perm.h"
 #include "utils/elog.h"
 
+#ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wunused-macros"
 #pragma GCC diagnostic ignored "-Wunused-value"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wextra"
+#endif
 
 /*
  * Errors handling
  * ----------------------------------------
  */
 
-#define tde_fe_errlog(_type, ...) \
-	({		\
-		if (tde_fe_error_level >= ERROR)		\
-			pg_log_error##_type(__VA_ARGS__);		\
-		else if (tde_fe_error_level >= WARNING)		\
-			pg_log_warning##_type(__VA_ARGS__);		\
-		else if (tde_fe_error_level >= LOG)		\
-			pg_log_info##_type(__VA_ARGS__);		\
-		else		\
-			pg_log_debug##_type(__VA_ARGS__);		\
-	})
+static int	tde_fe_error_level = 0;
 
-#define errmsg(...) tde_fe_errlog(, __VA_ARGS__)
-#define errhint(...) tde_fe_errlog(_hint, __VA_ARGS__)
-#define errdetail(...) tde_fe_errlog(_detail, __VA_ARGS__)
+static inline enum pg_log_level
+tde_fe_log_level(void)
+{
+	if (tde_fe_error_level >= ERROR)
+		return PG_LOG_ERROR;
+	else if (tde_fe_error_level >= WARNING)
+		return PG_LOG_WARNING;
+	else if (tde_fe_error_level >= LOG)
+		return PG_LOG_INFO;
+	else
+		return PG_LOG_DEBUG;
+}
+
+static inline int
+tde_fe_errlog_v(enum pg_log_part part, const char *fmt, va_list ap)
+{
+	pg_log_generic_v(tde_fe_log_level(), part, fmt, ap);
+	return 0;
+}
+
+static inline int tde_fe_errmsg(const char *fmt,...) pg_attribute_printf(1, 2);
+static inline int
+tde_fe_errmsg(const char *fmt,...)
+{
+	va_list		ap;
+
+	va_start(ap, fmt);
+	tde_fe_errlog_v(PG_LOG_PRIMARY, fmt, ap);
+	va_end(ap);
+	return 0;
+}
+
+static inline int tde_fe_errdetail(const char *fmt,...) pg_attribute_printf(1, 2);
+static inline int
+tde_fe_errdetail(const char *fmt,...)
+{
+	va_list		ap;
+
+	va_start(ap, fmt);
+	tde_fe_errlog_v(PG_LOG_DETAIL, fmt, ap);
+	va_end(ap);
+	return 0;
+}
+
+static inline int tde_fe_errhint(const char *fmt,...) pg_attribute_printf(1, 2);
+static inline int
+tde_fe_errhint(const char *fmt,...)
+{
+	va_list		ap;
+
+	va_start(ap, fmt);
+	tde_fe_errlog_v(PG_LOG_HINT, fmt, ap);
+	va_end(ap);
+	return 0;
+}
+
+#define errmsg(...) tde_fe_errmsg(__VA_ARGS__)
+#define errdetail(...) tde_fe_errdetail(__VA_ARGS__)
+#define errhint(...) tde_fe_errhint(__VA_ARGS__)
 
 #define errcode_for_file_access() NULL
 #define errcode(e) NULL
@@ -64,8 +114,6 @@
 		__VA_ARGS__;					\
 		tde_error_handle_exit(elevel);	\
 	} while(0)
-
-static int	tde_fe_error_level = 0;
 
 #define data_sync_elevel(elevel) (elevel)
 

--- a/src/keyring/keyring_file.c
+++ b/src/keyring/keyring_file.c
@@ -79,7 +79,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 							  (long long int) bytes_read, sizeof(KeyInfo)));
 			return NULL;
 		}
-		if (strncasecmp(key->name, key_name, sizeof(key->name)) == 0)
+		if (pg_strncasecmp(key->name, key_name, sizeof(key->name)) == 0)
 		{
 			CloseTransientFile(fd);
 			return key;


### PR DESCRIPTION
These changes fix most portability issues with MSVC.

One remaining issue after these is the KMIP library, which doesn't compile with it. We'll solve that by switching to the new library.

Not adding CI yet because it wouldn't work without the KMIP rework and EXEC_BACKEND fixes.

There are also additional PRs in the postgres repo that add a required DLLIMPORT attribute to md.