### PR TITLE
PG-2588 Disable timeout in KMIP code as a workaround

### DIFF
--- a/src/keyring/keyring_kmip.cpp
+++ b/src/keyring/keyring_kmip.cpp
@@ -25,8 +25,11 @@ extern "C"
 
 namespace
 {
-/* Timeout applied to connect, handshake and every read/write, in ms. */
-constexpr int KMIP_TIMEOUT_MS = 10000;
+/*
+ * TODO: Timeouts are disabled since they are broken in libkmip due a bug with
+ *       SA_RESTART and signals.
+ */
+constexpr int KMIP_TIMEOUT_MS = 0;
 
 /*
  * Run a kmipclient operation, translating any C++ exception it throws into


### PR DESCRIPTION
The timeout code in libkmip is broken when used in PostgreSQL due to it using `SO_RCVTIMEO` which does not work well when combined with PostgreSQL which relies on `SA_RESTART` and signals.

But as we did not have timeout support in pg_tde 2.2.1 this removal does not affect our users.