### PR TITLE
Do not reuse the curl handle across a fork

### DIFF
--- a/documentation/docs/release-notes/release-notes-v2.2.2.md
+++ b/documentation/docs/release-notes/release-notes-v2.2.2.md
@@ -38,3 +38,4 @@ Changes introduced in `pg_tde` 2.2.2:
 ### Bug Fixes
 
 - [PG-2492](https://perconadev.atlassian.net/browse/PG-2492) - Fixed crash when empty certificate parameters are passed to `pg_tde_add_global_key_provider_kmip()` or `pg_tde_add_database_key_provider_kmip()`
+- [PG-2608](https://perconadev.atlassian.net/browse/PG-2608) - Fixed a race condition in the Vault key provider that could occur when multiple processes accessed the same cURL handle after a fork.

--- a/src/keyring/keyring_curl.c
+++ b/src/keyring/keyring_curl.c
@@ -4,10 +4,13 @@
 
 #include "postgres.h"
 
+#include <unistd.h>
+
 #include "keyring/keyring_curl.h"
 #include "pg_tde_defines.h"
 
 CURL	   *keyringCurl = NULL;
+static pid_t keyringCurlPid = 0;
 
 static size_t
 write_func(void *ptr, size_t size, size_t nmemb, struct CurlString *s)
@@ -29,12 +32,23 @@ write_func(void *ptr, size_t size, size_t nmemb, struct CurlString *s)
 bool
 curlSetupSession(const char *url, const char *caFile, CurlString *outStr)
 {
-	if (keyringCurl == NULL)
+	/*
+	 * A handle created before a fork keeps the parent's connection cache, so
+	 * the socket is shared with the parent and every other child. Two
+	 * processes writing to it interleave their requests on one stream. Start
+	 * over whenever we notice we are in a different process.
+	 *
+	 * The inherited handle is abandoned rather than cleaned up: cleanup would
+	 * send a TLS shutdown over the connection the parent still uses.
+	 */
+	if (keyringCurl == NULL || keyringCurlPid != getpid())
 	{
 		keyringCurl = curl_easy_init();
 
 		if (keyringCurl == NULL)
 			return false;
+
+		keyringCurlPid = getpid();
 	}
 	else
 	{


### PR DESCRIPTION
The postmaster does keyring requests while generating the WAL key, so keyringCurl and its keepalive socket get inherited by every child. Two processes then interleave HTTP on the same connection, which surfaces as CURLE_WEIRD_SERVER_REPLY, a timeout, or a garbled response body.

Re-init the handle when the pid changed. The inherited handle is abandoned instead of cleaned up, because curl_easy_cleanup would write a TLS shutdown to the connection the parent still uses.