### PR TITLE
Make WAL archive tools work with pg_wal as symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+- Make WAL archive tools work with pg_wal dir as symlink ([PG-2609](https://perconadev.atlassian.net/browse/PG-2609))

--- a/documentation/docs/release-notes/release-notes-v2.2.2.md
+++ b/documentation/docs/release-notes/release-notes-v2.2.2.md
@@ -39,3 +39,4 @@ Changes introduced in `pg_tde` 2.2.2:
 
 - [PG-2492](https://perconadev.atlassian.net/browse/PG-2492) - Fixed crash when empty certificate parameters are passed to `pg_tde_add_global_key_provider_kmip()` or `pg_tde_add_database_key_provider_kmip()`
 - [PG-2608](https://perconadev.atlassian.net/browse/PG-2608) - Fixed a race condition in the Vault key provider that could occur when multiple processes accessed the same cURL handle after a fork.
+- [PG-2609](https://perconadev.atlassian.net/browse/PG-2609) - Fixed WAL archiving (`pg_tde_archive_decrypt` and `pg_tde_restore_encrypt`) when pg_wal dir is a symlink.

--- a/meson.build
+++ b/meson.build
@@ -379,6 +379,7 @@ tap_tests = [
   't/tde_heap.pl',
   't/unlogged_tables.pl',
   't/vault_v2.pl',
+  't/wal_archiving_symlink.pl',
   't/wal_archiving.pl',
   't/wal_encrypt.pl',
   't/wal_key_tli.pl',

--- a/src/bin/pg_tde_fe_archive_common.h
+++ b/src/bin/pg_tde_fe_archive_common.h
@@ -19,6 +19,14 @@ derive_tde_dir_from_segment_path(const char *segpath, const char *sep,
 
 		strlcpy(segdir, segpath, sep - segpath + 1);
 		snprintf(tdedir, tdedir_sz, "%s/../" PG_TDE_DATA_DIR, segdir);
+
+		/*
+		 * tdedir most probaly is "pg_wal/../pg_tde" now, but it won't work if
+		 * pg_wal is a symlink directing outside the datadir. In such a case,
+		 * canonicalization will remove the reference to pg_wal, making path
+		 * just "pg_tde". And it won't do any harm for other cases.
+		 */
+		canonicalize_path(tdedir);
 	}
 	else
 	{

--- a/t/wal_archiving_symlink.pl
+++ b/t/wal_archiving_symlink.pl
@@ -1,0 +1,89 @@
+# Check that WAL archiving works when pg_wal is a symlink.
+use strict;
+use warnings FATAL => 'all';
+use File::Copy;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+# Test CLI tools directly
+
+# Wal archiving uses linux specific tmpfs mount point for temporary files.
+if ($^O ne 'linux')
+{
+	plan skip_all => 'tde wal_archiving works only on Linux';
+	exit 0;
+}
+
+my $keydir = PostgreSQL::Test::Utils::tempdir;
+my $wal_dir = PostgreSQL::Test::Utils::tempdir;
+
+# Test archive_command
+
+my $primary = PostgreSQL::Test::Cluster->new('primary');
+my $archive_dir = $primary->archive_dir;
+$primary->init(allows_streaming => 1);
+$primary->append_conf('postgresql.conf',
+	"shared_preload_libraries = 'pg_tde'");
+$primary->append_conf('postgresql.conf', "wal_level = 'replica'");
+$primary->append_conf('postgresql.conf', "autovacuum = off");
+$primary->append_conf('postgresql.conf', "checkpoint_timeout = 1h");
+$primary->append_conf('postgresql.conf', "archive_mode = on");
+$primary->append_conf('postgresql.conf',
+	"archive_command = 'pg_tde_archive_decrypt %f %p \"cp %%p $archive_dir/%%f\"'"
+);
+
+my $test_primary_datadir = $primary->data_dir;
+
+# Turn pg_wal into a symlink
+print("moving $test_primary_datadir/pg_wal to $wal_dir\n");
+move("$test_primary_datadir/pg_wal", $wal_dir)
+  or BAIL_OUT("cannot move pg_wal: $!");
+dir_symlink($wal_dir, "$test_primary_datadir/pg_wal")
+  or BAIL_OUT("cannot create a symlink to pg_wal: $!");
+
+$primary->start;
+
+$primary->safe_psql('postgres', "CREATE EXTENSION pg_tde;");
+$primary->safe_psql('postgres',
+	"SELECT pg_tde_add_global_key_provider_file('keyring', '$keydir/global.keys');"
+);
+$primary->safe_psql('postgres',
+	"SELECT pg_tde_create_key_using_global_key_provider('server-key', 'keyring');"
+);
+$primary->safe_psql('postgres',
+	"SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'keyring');"
+);
+
+$primary->append_conf('postgresql.conf', "pg_tde.wal_encrypt = on");
+$primary->restart;
+
+# "-X none" ensures no WAL in the backup; hence, it must be restored from the archive
+$primary->backup('backup1', backup_options => [ '-X', 'none' ]);
+
+$primary->safe_psql('postgres', "CREATE TABLE t1 AS SELECT 'foobar' AS x");
+
+$primary->stop;
+
+ok( !$primary->log_contains('pg_tde_archive_decrypt'),
+	'verify there are no pg_tde_archive_decrypt messages in log');
+
+my $replica = PostgreSQL::Test::Cluster->new('replica');
+$replica->init_from_backup($primary, 'backup1');
+$replica->append_conf('postgresql.conf',
+	"restore_command = 'pg_tde_restore_encrypt %f %p \"cp $archive_dir/%%f %%p\"'"
+);
+$replica->set_standby_mode;
+$replica->start;
+
+$replica->wait_for_log("waiting for WAL to become available");
+
+$replica->promote;
+
+# Check that data restored from the WAL archive is readable
+my $result = $replica->safe_psql('postgres', 'SELECT * FROM t1');
+is($result, "foobar", 'data is readable after restore');
+
+$replica->stop;
+
+done_testing();


### PR DESCRIPTION
When deriving the pg_tde path from the WAL source, archive tools in the default env will get "pg_wal/../pg_tde". But it won't work if pg_wal is a symlink directing outside the datadir. So we add canonicalize_path to make such a path just "pg_tde".

Fixes PG-2609