### PR TITLE
Remove Github codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-# Order is important; the last matching pattern takes the most precedence.
-
-/documentation/ @nastena1606 @Andriciuc


### PR DESCRIPTION
As Dragos and Anastasia no longer are on the team and we at least for now work in a totally different way with our documentation having them assigned to issues no longer makes any sense.